### PR TITLE
fix: replace use tooltip instead of toast for show tip information

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-toastify": "^9.1.1",
+    "react-tooltip": "^5.26.3",
     "urql": "^3.0.3",
     "wagmi": "0.12.18",
     "zod": "^3.21.2",

--- a/src/components/icons/HelpIcon.tsx
+++ b/src/components/icons/HelpIcon.tsx
@@ -1,13 +1,12 @@
 import { memo } from 'react';
-import { toast } from 'react-toastify';
 
 import Question from '../../images/icons/question-circle.svg';
 import { IconButton } from '../buttons/IconButton';
 
 function _HelpIcon({ text, size = 20 }: { text: string; size?: number }) {
-  const onClick = () => {
-    toast.info(text, { autoClose: 8000 });
-  };
+  // const onClick = () => {
+  //   toast.info(text, { autoClose: 8000 });
+  // };
 
   return (
     <IconButton
@@ -15,8 +14,13 @@ function _HelpIcon({ text, size = 20 }: { text: string; size?: number }) {
       title="Help"
       width={size}
       height={size}
-      onClick={onClick}
+      // onClick={onClick}
       classes="opacity-50"
+      passThruProps={{
+        'data-tooltip-content': text,
+        'data-tooltip-id': 'my-tooltip',
+        'data-tooltip-place': 'top-start',
+      }}
     />
   );
 }

--- a/src/components/icons/HelpIcon.tsx
+++ b/src/components/icons/HelpIcon.tsx
@@ -1,24 +1,22 @@
 import { memo } from 'react';
 
+
+
 import Question from '../../images/icons/question-circle.svg';
 import { IconButton } from '../buttons/IconButton';
 
-function _HelpIcon({ text, size = 20 }: { text: string; size?: number }) {
-  // const onClick = () => {
-  //   toast.info(text, { autoClose: 8000 });
-  // };
 
+function _HelpIcon({ text, size = 20 }: { text: string; size?: number }) {
   return (
     <IconButton
       imgSrc={Question}
       title="Help"
       width={size}
       height={size}
-      // onClick={onClick}
       classes="opacity-50"
       passThruProps={{
         'data-tooltip-content': text,
-        'data-tooltip-id': 'my-tooltip',
+        'data-tooltip-id': 'root-tooltip',
         'data-tooltip-place': 'top-start',
       }}
     />

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,6 +9,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { AppProps } from 'next/app';
 import { ToastContainer, Zoom, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+import { Tooltip } from 'react-tooltip';
 import { Provider as UrqlProvider, createClient as createUrqlClient } from 'urql';
 
 import '@hyperlane-xyz/widgets/styles.css';
@@ -84,6 +85,7 @@ export default function App({ Component, router, pageProps }: AppProps) {
         </UrqlProvider>
       </QueryClientProvider>
       <ToastContainer transition={Zoom} position={toast.POSITION.BOTTOM_RIGHT} limit={2} />
+      <Tooltip id="my-tooltip" className="z-50" />
       {/* </RainbowKitProvider> */}
       {/* </WagmiConfig> */}
     </ErrorBoundary>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -85,7 +85,7 @@ export default function App({ Component, router, pageProps }: AppProps) {
         </UrqlProvider>
       </QueryClientProvider>
       <ToastContainer transition={Zoom} position={toast.POSITION.BOTTOM_RIGHT} limit={2} />
-      <Tooltip id="my-tooltip" className="z-50" />
+      <Tooltip id="root-tooltip" className="z-50" />
       {/* </RainbowKitProvider> */}
       {/* </WagmiConfig> */}
     </ErrorBoundary>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1283,6 +1283,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^1.0.0":
+  version: 1.6.0
+  resolution: "@floating-ui/core@npm:1.6.0"
+  dependencies:
+    "@floating-ui/utils": "npm:^0.2.1"
+  checksum: d6a47cacde193cd8ccb4c268b91ccc4ca254dffaec6242b07fd9bcde526044cc976d27933a7917f9a671de0a0e27f8d358f46400677dbd0c8199de293e9746e1
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.6.1":
+  version: 1.6.3
+  resolution: "@floating-ui/dom@npm:1.6.3"
+  dependencies:
+    "@floating-ui/core": "npm:^1.0.0"
+    "@floating-ui/utils": "npm:^0.2.0"
+  checksum: 83e97076c7a5f55c3506f574bc53f03d38bed6eb8181920c8733076889371e287e9ae6f28c520a076967759b9b6ff425362832a5cdf16a999069530dbb9cce53
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.0, @floating-ui/utils@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "@floating-ui/utils@npm:0.2.1"
+  checksum: 33c9ab346e7b05c5a1e6a95bc902aafcfc2c9d513a147e2491468843bd5607531b06d0b9aa56aa491cbf22a6c2495c18ccfc4c0344baec54a689a7bb8e4898d6
+  languageName: node
+  linkType: hard
+
 "@gar/promisify@npm:^1.1.3":
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
@@ -1387,6 +1413,7 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     react-toastify: "npm:^9.1.1"
+    react-tooltip: "npm:^5.26.3"
     tailwindcss: "npm:^3.3.3"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.1.6"
@@ -4657,6 +4684,13 @@ __metadata:
   version: 1.2.2
   resolution: "cjs-module-lexer@npm:1.2.2"
   checksum: f80f84bfdcc53379cc18e25ea3c0cdb4595c142b8e28df304f5c88f38202e1bccf13e845401593656781f79fb43273e1d402d6187d0eeee8dca5ddecee1dcad4
+  languageName: node
+  linkType: hard
+
+"classnames@npm:^2.3.0":
+  version: 2.5.1
+  resolution: "classnames@npm:2.5.1"
+  checksum: 58eb394e8817021b153bb6e7d782cfb667e4ab390cb2e9dac2fc7c6b979d1cc2b2a733093955fc5c94aa79ef5c8c89f11ab77780894509be6afbb91dddd79d15
   languageName: node
   linkType: hard
 
@@ -9217,6 +9251,19 @@ __metadata:
     react: ">=16"
     react-dom: ">=16"
   checksum: d49f332cd2196c7f68507e947f45edbb048b3625f6706b0bea4d27a75fef1dd4501cf327712a7cc5a7fbb8b0fb8bc0ef347ad8ae8714f0cd7c960f89f187521e
+  languageName: node
+  linkType: hard
+
+"react-tooltip@npm:^5.26.3":
+  version: 5.26.3
+  resolution: "react-tooltip@npm:5.26.3"
+  dependencies:
+    "@floating-ui/dom": "npm:^1.6.1"
+    classnames: "npm:^2.3.0"
+  peerDependencies:
+    react: ">=16.14.0"
+    react-dom: ">=16.14.0"
+  checksum: be17e091e53c98b2295c6429c13f0631bfaf559f1f8577fc805d0b2dd91c087cccf834f068a34492d1fa6b4bee1236a5c6635b1b751910b23f539eceacb864c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We should use tooltips to display tip information instead of Toasts.

**Reasons:**

- Users have to shift their focus from the current help area to the bottom right corner, resulting in poor user experience. It becomes unclear which help was hovered over after moving the mouse.
- Toasts have a delay that is too long and are limited to a maximum of two. Even when moving to another location or page, they still appear and continue to display if clicked multiple times.

**Solution:**
- Implement tooltips using [react-tooltip](https://react-tooltip.com/docs/getting-started).
- Remove the onClick event and display tooltips instead of Toasts.

I have some demo videos here:
Before:

https://github.com/hyperlane-xyz/hyperlane-explorer/assets/15717476/67bc4d5a-c29f-4fb8-9a09-a96640b66da0

After:

https://github.com/hyperlane-xyz/hyperlane-explorer/assets/15717476/f515aa63-3e54-4d07-a9c6-aede39e808ab


