### PR TITLE
fix: add time elapsed in transaction list (Home)

### DIFF
--- a/src/components/timer/TimeElapsed.tsx
+++ b/src/components/timer/TimeElapsed.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+import { getHumanReadableTimeString } from '../../utils/time';
+
+type TimeElapsedProps = {
+  timestamp: number;
+};
+
+const TimeElapsed = ({ timestamp }: TimeElapsedProps) => {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => setCount((count) => count + 1), 1000);
+    return () => clearInterval(interval);
+  }, [timestamp]);
+
+  return <span key={count}>{getHumanReadableTimeString(timestamp)}</span>;
+};
+
+export default TimeElapsed;

--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -1,14 +1,19 @@
 import Link from 'next/link';
 import { PropsWithChildren } from 'react';
 
+
+
 import { MultiProvider } from '@hyperlane-xyz/sdk';
 import { shortenAddress } from '@hyperlane-xyz/utils';
 
 import { ChainLogo } from '../../components/icons/ChainLogo';
+import TimeElapsed from '../../components/timer/TimeElapsed';
 import { MessageStatus, MessageStub } from '../../types';
-import { getHumanReadableDuration, getHumanReadableTimeString } from '../../utils/time';
+import { getHumanReadableDuration } from '../../utils/time';
 import { getChainDisplayName } from '../chains/utils';
 import { useMultiProvider } from '../providers/multiProvider';
+
+
 
 import { serializeMessage } from './utils';
 
@@ -94,7 +99,7 @@ export function MessageSummaryRow({ message, mp }: { message: MessageStub; mp: M
         {shortenAddress(recipient) || 'Invalid Address'}
       </LinkCell>
       <LinkCell id={msgId} base64={base64} aClasses={styles.valueTruncated}>
-        {getHumanReadableTimeString(origin.timestamp)}
+        <TimeElapsed timestamp={origin.timestamp} />
       </LinkCell>
       <LinkCell
         id={msgId}


### PR DESCRIPTION
**Issues: UX performance about transaction list in page /home**

We should have a time elapsed in transaction list (Home Screen) for better UX.

Solutions: 
- Add a **TimeElapsed.tsx** component with setInterval each second for checking new value of readable time string
- Replace current function string to **TimeElapsed** component only on Home screen

https://github.com/hyperlane-xyz/hyperlane-explorer/assets/15717476/39d7fcdf-6cdb-40ce-85ce-acec3ee3b2e7

