### PR TITLE
fix: error query with non-evm chainId when search

### DIFF
--- a/src/components/search/SearchFilterBar.tsx
+++ b/src/components/search/SearchFilterBar.tsx
@@ -92,7 +92,8 @@ function ChainMultiSelector({
     );
     const mainnets = coreEvmChains.filter((c) => !c.isTestnet);
     const testnets = coreEvmChains.filter((c) => !!c.isTestnet);
-    return { chains, mainnets, testnets };
+    // Return only evnChains because of graphql only accept query non-evm chains (with bigint type not string)
+    return { chains: coreEvmChains, mainnets, testnets };
   }, [multiProvider]);
 
   // Need local state as buffer before user hits apply


### PR DESCRIPTION
## Description
Add wrong query chainId when search 
Issue: https://github.com/hyperlane-xyz/hyperlane-explorer/issues/91

## Solution
Return only evm chain with bigint type not string

```diff
-  return { chains, mainnets, testnets };
+  // Return only evnChains because of graphql only accept query non-evm chains (with bigint type not string)
+  return { chains: coreEvmChains, mainnets, testnets };
```