### PR TITLE
feat: scrollable search filter

### DIFF
--- a/src/components/search/SearchFilterBar.tsx
+++ b/src/components/search/SearchFilterBar.tsx
@@ -190,9 +190,7 @@ function ChainMultiSelector({
             </div>
           </div>
           <div className="mt-2.5 flex space-x-2">
-            <div
-              className="flex flex-col overflow-x-hidden overflow-y-auto max-h-100"
-            >
+            <div className="flex flex-col overflow-x-hidden overflow-y-auto max-h-100">
               <div className="pb-1.5">
                 <CheckBox
                   checked={!hasAnyUncheckedChain(mainnets)}
@@ -218,9 +216,7 @@ function ChainMultiSelector({
                 </CheckBox>
               ))}
             </div>
-            <div
-              className="flex flex-col overflow-x-hidden overflow-y-auto max-h-100"
-            >
+            <div className="flex flex-col overflow-x-hidden overflow-y-auto max-h-100">
               <div className="pb-1.5">
                 <CheckBox
                   checked={!hasAnyUncheckedChain(testnets)}

--- a/src/components/search/SearchFilterBar.tsx
+++ b/src/components/search/SearchFilterBar.tsx
@@ -219,8 +219,7 @@ function ChainMultiSelector({
               ))}
             </div>
             <div
-              className="flex flex-col overflow-y-auto max-h-100"
-              style={{ overflowX: 'hidden' }}
+              className="flex flex-col overflow-x-hidden overflow-y-auto max-h-100"
             >
               <div className="pb-1.5">
                 <CheckBox

--- a/src/components/search/SearchFilterBar.tsx
+++ b/src/components/search/SearchFilterBar.tsx
@@ -189,8 +189,11 @@ function ChainMultiSelector({
               </TextButton>
             </div>
           </div>
-          <div className="mt-2.5 flex space-x-6">
-            <div className="flex flex-col">
+          <div className="mt-2.5 flex space-x-2">
+            <div
+              className="flex flex-col overflow-y-auto max-h-100"
+              style={{ overflowX: 'hidden' }}
+            >
               <div className="pb-1.5">
                 <CheckBox
                   checked={!hasAnyUncheckedChain(mainnets)}
@@ -216,8 +219,10 @@ function ChainMultiSelector({
                 </CheckBox>
               ))}
             </div>
-            <div className="self-stretch w-px my-1 bg-gray-100"></div>
-            <div className="flex flex-col">
+            <div
+              className="flex flex-col overflow-y-auto max-h-100"
+              style={{ overflowX: 'hidden' }}
+            >
               <div className="pb-1.5">
                 <CheckBox
                   checked={!hasAnyUncheckedChain(testnets)}

--- a/src/components/search/SearchFilterBar.tsx
+++ b/src/components/search/SearchFilterBar.tsx
@@ -191,8 +191,7 @@ function ChainMultiSelector({
           </div>
           <div className="mt-2.5 flex space-x-2">
             <div
-              className="flex flex-col overflow-y-auto max-h-100"
-              style={{ overflowX: 'hidden' }}
+              className="flex flex-col overflow-x-hidden overflow-y-auto max-h-100"
             >
               <div className="pb-1.5">
                 <CheckBox


### PR DESCRIPTION
feat: scrollable search filter

much needed now that our set of supported chains is taller than a vertical monitor

<img width="405" alt="image" src="https://github.com/user-attachments/assets/e026e99f-d68c-46e5-b720-05a0e10d849b">
