### PR TITLE
fix: header scroll looping and firefox issue

### DIFF
--- a/src/components/nav/Header.tsx
+++ b/src/components/nav/Header.tsx
@@ -25,14 +25,14 @@ export function Header({ pathName }: { pathName: string }) {
 
   return (
     <header
-      className={`sticky top-0 z-10 w-full bg-blue-500 px-2 transition-all duration-200 ease-in-out will-change-[border,padding] sm:px-6 lg:px-12 ${
+      className={`sticky top-0 z-10 w-full bg-blue-500 px-2 transition-all duration-200 ease-in-out will-change-[border,padding,transform] sm:px-6 lg:px-12 ${
         animateHeader ? 'border-b border-white py-1' : 'py-4 sm:py-5'
       }`}
     >
       <div className="flex items-center justify-between">
         <Link href="/" className="flex items-center">
           <div
-            className={`flex items-center will-change-transform ${
+            className={`flex items-center ${
               animateHeader && 'scale-90'
             } transition-all duration-500 ease-in-out`}
             style={{

--- a/src/components/nav/Header.tsx
+++ b/src/components/nav/Header.tsx
@@ -25,16 +25,19 @@ export function Header({ pathName }: { pathName: string }) {
 
   return (
     <header
-      className={`sticky top-0 z-10 w-full bg-blue-500 px-2 transition-all duration-200 ease-in-out sm:px-6 lg:px-12 ${
+      className={`sticky top-0 z-10 w-full bg-blue-500 px-2 transition-all duration-200 ease-in-out will-change-[border,padding] sm:px-6 lg:px-12 ${
         animateHeader ? 'border-b border-white py-1' : 'py-4 sm:py-5'
       }`}
     >
       <div className="flex items-center justify-between">
         <Link href="/" className="flex items-center">
           <div
-            className={`flex items-center ${
+            className={`flex items-center will-change-transform ${
               animateHeader && 'scale-90'
             } transition-all duration-500 ease-in-out`}
+            style={{
+              transform: 'translateZ(0)',
+            }}
           >
             <Image src={Logo} alt="" className="h-7 w-auto sm:h-8" />
             <Image src={Name} alt="Hyperlane" className="ml-3 mt-1 hidden h-6 w-auto sm:block" />


### PR DESCRIPTION
## Scroll loop fix
Prevents scrolling until debouncing finishes, this will fix the issue where it will loop the scroll because the height of the page changes. 

Caveat: Still trying to find a solution to the scrolling if it's too fast which might cause the scroll not to register if it cross the threshold

## Firefox animation fix
Fixed an issue with `firefox` choppy and slow animation, basically some browsers struggle with animation because of the way they render a page, so by adding `will-change` to the specific properties it will tell the browser that a particular css property is gonna change.

An alternative and more hacky way to do this is by adding `transform: translateZ(0)` which will forces hardware acceleration and offload the animation the GPU. Although will-change is stated as a last resort in https://developer.mozilla.org/en-US/docs/Web/CSS/will-change, it seems to be an acceptable solution for these edge cases