### PR TITLE
fix: header scroll looping and firefox slow animation

### DIFF
--- a/src/components/nav/Header.tsx
+++ b/src/components/nav/Header.tsx
@@ -31,6 +31,8 @@ export function Header({ pathName }: { pathName: string }) {
     >
       <div className="flex items-center justify-between">
         <Link href="/" className="flex items-center">
+          {/* We are adding a minimal rotation here to trick the browser to go into hardware acceleration mode
+            this will this little animation smoother, specially for Firefox*/}
           <div
             className={`flex items-center ${
               animateHeader && 'rotate-[0.01deg] scale-90'

--- a/src/components/nav/Header.tsx
+++ b/src/components/nav/Header.tsx
@@ -25,7 +25,7 @@ export function Header({ pathName }: { pathName: string }) {
 
   return (
     <header
-      className={`sticky top-0 z-10 w-full bg-blue-500 px-2 transition-all duration-200 ease-in-out will-change-[border,padding,transform] sm:px-6 lg:px-12 ${
+      className={`sticky top-0 z-10 w-full bg-blue-500 px-2 transition-all duration-200 ease-in-out sm:px-6 lg:px-12 ${
         animateHeader ? 'border-b border-white py-1' : 'py-4 sm:py-5'
       }`}
     >
@@ -33,11 +33,8 @@ export function Header({ pathName }: { pathName: string }) {
         <Link href="/" className="flex items-center">
           <div
             className={`flex items-center ${
-              animateHeader && 'scale-90'
+              animateHeader && 'rotate-[0.01deg] scale-90'
             } transition-all duration-500 ease-in-out`}
-            style={{
-              transform: 'translateZ(0)',
-            }}
           >
             <Image src={Logo} alt="" className="h-7 w-auto sm:h-8" />
             <Image src={Name} alt="Hyperlane" className="ml-3 mt-1 hidden h-6 w-auto sm:block" />

--- a/src/components/nav/Header.tsx
+++ b/src/components/nav/Header.tsx
@@ -31,7 +31,7 @@ export function Header({ pathName }: { pathName: string }) {
     >
       <div className="flex items-center justify-between">
         <Link href="/" className="flex items-center">
-          {/* We are adding a minimal rotation here to trick the browser to go into hardware acceleration mode
+          {/* Add a minimal rotation here to trick the browser to go into hardware acceleration mode
             this will make the animation a little smoother, specially for Firefox*/}
           <div
             className={`flex items-center ${

--- a/src/components/nav/Header.tsx
+++ b/src/components/nav/Header.tsx
@@ -32,7 +32,7 @@ export function Header({ pathName }: { pathName: string }) {
       <div className="flex items-center justify-between">
         <Link href="/" className="flex items-center">
           {/* We are adding a minimal rotation here to trick the browser to go into hardware acceleration mode
-            this will this little animation smoother, specially for Firefox*/}
+            this will make the animation a little smoother, specially for Firefox*/}
           <div
             className={`flex items-center ${
               animateHeader && 'rotate-[0.01deg] scale-90'

--- a/src/components/nav/Header.tsx
+++ b/src/components/nav/Header.tsx
@@ -25,14 +25,14 @@ export function Header({ pathName }: { pathName: string }) {
 
   return (
     <header
-      className={`sticky top-0 z-10 w-full bg-blue-500 px-2 transition-all duration-200 ease-in-out will-change-[border,padding] sm:px-6 lg:px-12 ${
+      className={`sticky top-0 z-10 w-full bg-blue-500 px-2 transition-all duration-200 ease-in-out will-change-[border,padding,transform] sm:px-6 lg:px-12 ${
         animateHeader ? 'border-b border-white py-1' : 'py-4 sm:py-5'
       }`}
     >
       <div className="flex items-center justify-between">
         <Link href="/" className="flex items-center">
           <div
-            className={`flex items-center will-change-transform ${
+            className={`flex items-center ${
               animateHeader && 'scale-90'
             } transition-all duration-500 ease-in-out`}
             style={{

--- a/src/components/nav/Header.tsx
+++ b/src/components/nav/Header.tsx
@@ -25,16 +25,19 @@ export function Header({ pathName }: { pathName: string }) {
 
   return (
     <header
-      className={`sticky top-0 z-10 w-full bg-blue-500 px-2 transition-all duration-200 ease-in-out sm:px-6 lg:px-12 ${
+      className={`sticky top-0 z-10 w-full bg-blue-500 px-2 transition-all duration-200 ease-in-out will-change-[border,padding] sm:px-6 lg:px-12 ${
         animateHeader ? 'border-b border-white py-1' : 'py-4 sm:py-5'
       }`}
     >
       <div className="flex items-center justify-between">
         <Link href="/" className="flex items-center">
           <div
-            className={`flex items-center ${
+            className={`flex items-center will-change-transform ${
               animateHeader && 'scale-90'
             } transition-all duration-500 ease-in-out`}
+            style={{
+              transform: 'translateZ(0)',
+            }}
           >
             <Image src={Logo} alt="" className="h-7 w-auto sm:h-8" />
             <Image src={Name} alt="Hyperlane" className="ml-3 mt-1 hidden h-6 w-auto sm:block" />

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -1,3 +1,0 @@
-export function isFirefox() {
-  return typeof navigator !== 'undefined' && navigator.userAgent.toLowerCase().includes('firefox');
-}

--- a/src/utils/useScrollListener.ts
+++ b/src/utils/useScrollListener.ts
@@ -1,50 +1,44 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-export function useScrollThresholdListener(threshold: number, debounceTime = 200) {
+export function useScrollThresholdListener(threshold: number, debounce = 300) {
   const [isAboveThreshold, setIsAbove] = useState(false);
   const [isDebouncing, setIsDebouncing] = useState(false);
 
-  const timeoutId = useRef<null | NodeJS.Timeout>(null);
-
-  const handleScroll = useCallback(() => {
-    if (isDebouncing) return; // Skip handling scroll when disabled
-
-    if (window.scrollY > threshold && !isAboveThreshold) {
-      setIsAbove(true);
-      setIsDebouncing(true);
-    } else if (window.scrollY <= threshold && isAboveThreshold) {
-      setIsAbove(false);
-      setIsDebouncing(true);
-    }
-  }, [threshold, isAboveThreshold, isDebouncing]);
-
-  const debouncedHandleScroll = debounce(handleScroll, 20);
+  const timeoutId = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
-    if (isDebouncing && !timeoutId.current) {
-      timeoutId.current = setTimeout(() => {
-        setIsDebouncing(false);
-        timeoutId.current = null;
-      }, debounceTime);
-    }
+    const listener = () => {
+      const handleScroll = () => {
+        if (isDebouncing) return;
 
-    window.addEventListener('scroll', debouncedHandleScroll, { passive: true });
+        if (window.scrollY > threshold && !isAboveThreshold) {
+          setIsAbove(true);
+          setIsDebouncing(true);
+        } else if (window.scrollY <= threshold && isAboveThreshold) {
+          setIsAbove(false);
+          setIsDebouncing(true);
+        }
+      };
 
+      if (isDebouncing) {
+        if (!timeoutId.current) {
+          timeoutId.current = setTimeout(() => {
+            setIsDebouncing(false);
+            timeoutId.current = null;
+            handleScroll();
+          }, debounce);
+        }
+      } else {
+        handleScroll();
+      }
+    };
+
+    window.addEventListener('scroll', listener, { passive: true });
     return () => {
-      window.removeEventListener('scroll', debouncedHandleScroll);
+      window.removeEventListener('scroll', listener);
       if (timeoutId.current) clearTimeout(timeoutId.current);
     };
-  }, [debouncedHandleScroll, isDebouncing, debounceTime]);
+  }, [threshold, debounce, isAboveThreshold, isDebouncing]);
 
   return isAboveThreshold;
-}
-
-function debounce(fn: () => void, delay: number) {
-  let timeoutId: number;
-  return function () {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
-    timeoutId = window.setTimeout(fn, delay);
-  };
 }

--- a/src/utils/useScrollListener.ts
+++ b/src/utils/useScrollListener.ts
@@ -28,7 +28,7 @@ export function useScrollThresholdListener(threshold: number, debounceTime = 200
       }, debounceTime);
     }
 
-    window.addEventListener('scroll', debouncedHandleScroll);
+    window.addEventListener('scroll', debouncedHandleScroll, { passive: true });
 
     return () => {
       window.removeEventListener('scroll', debouncedHandleScroll);


### PR DESCRIPTION
## Scroll loop fix
Fixed an issue where on some specific threshold it would cause the header to loop the scaling animation because of the height changes. Move timeoutId so the variable is not re-created everytime and added a missing logic that would prevent proper debouncing

Caveat: If the scroll is extremely fast it might cause the header to be stuck on a certain threshold until a new scroll happens

## Firefox animation fix
Fixed an issue with `Firefox` choppy and slow animation, basically some browsers struggle with animation because of the way they render a page, so the "trick" is to make the browser go into hardware acceleration mode by adding a slight `rotation` and this way the animations will run smoother

On Firefox if you pay really close attention there's still a bit of a delay/blurriness that is almost not noticeable when the animation finishes
