### PR TITLE
Update useScrollListener.ts

### DIFF
--- a/src/utils/useScrollListener.ts
+++ b/src/utils/useScrollListener.ts
@@ -2,34 +2,24 @@ import { useEffect, useRef, useState } from 'react';
 
 export function useScrollThresholdListener(threshold: number, debounce = 300) {
   const [isAboveThreshold, setIsAbove] = useState(false);
-  const [isDebouncing, setIsDebouncing] = useState(false);
 
   const timeoutId = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     const listener = () => {
       const handleScroll = () => {
-        if (isDebouncing) return;
-
         if (window.scrollY > threshold && !isAboveThreshold) {
           setIsAbove(true);
-          setIsDebouncing(true);
         } else if (window.scrollY <= threshold && isAboveThreshold) {
           setIsAbove(false);
-          setIsDebouncing(true);
         }
       };
 
-      if (isDebouncing) {
-        if (!timeoutId.current) {
-          timeoutId.current = setTimeout(() => {
-            setIsDebouncing(false);
-            timeoutId.current = null;
-            handleScroll();
-          }, debounce);
-        }
-      } else {
-        handleScroll();
+      if (!timeoutId.current) {
+        timeoutId.current = setTimeout(() => {
+          handleScroll();
+          timeoutId.current = null;
+        }, debounce);
       }
     };
 
@@ -38,7 +28,7 @@ export function useScrollThresholdListener(threshold: number, debounce = 300) {
       window.removeEventListener('scroll', listener);
       if (timeoutId.current) clearTimeout(timeoutId.current);
     };
-  }, [threshold, debounce, isAboveThreshold, isDebouncing]);
+  }, [threshold, debounce, isAboveThreshold]);
 
   return isAboveThreshold;
 }


### PR DESCRIPTION
I've removed the isDebouncing variable which was used to track whether the delay was active. Instead, timeout management is now controlled solely by timeoutId. This simplifies the code, as we no longer need to check the status of the offset each time. The timer (timeoutId) takes care of managing the wait between checks.