### PR TITLE
fix: tryGetChainName instead of hard crashing

### DIFF
--- a/src/features/deliveryStatus/fetchDeliveryStatus.ts
+++ b/src/features/deliveryStatus/fetchDeliveryStatus.ts
@@ -25,7 +25,11 @@ export async function fetchDeliveryStatus(
   overrideChainMetadata: ChainMap<Partial<ChainMetadata>>,
   message: Message,
 ): Promise<MessageDeliveryStatusResponse> {
-  const destName = multiProvider.getChainName(message.destinationDomainId);
+  const destName = multiProvider.tryGetChainName(message.destinationDomainId);
+  if (!destName)
+    throw new Error(
+      `Cannot check delivery status, no chain name provided for domain ${message.destinationDomainId}`,
+    );
   const destMailboxAddr = await getMailboxAddress(destName, overrideChainMetadata, registry);
   if (!destMailboxAddr)
     throw new Error(

--- a/src/features/messages/MessageDetails.tsx
+++ b/src/features/messages/MessageDetails.tsx
@@ -88,8 +88,8 @@ export function MessageDetails({ messageId, message: messageFromUrlParams }: Pro
   // Banner color setter
   useDynamicBannerColor(isFetching, status, isMessageFound, isError || isPiError);
 
-  const originChainName = multiProvider.getChainName(originDomainId);
-  const destinationChainName = multiProvider.getChainName(destinationDomainId);
+  const originChainName = multiProvider.tryGetChainName(originDomainId) || 'Unknown';
+  const destinationChainName = multiProvider.tryGetChainName(destinationDomainId) || 'Unknown';
 
   return (
     <>

--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -67,8 +67,8 @@ export function MessageSummaryRow({ message, mp }: { message: MessageStub; mp: M
 
   const base64 = message.isPiMsg ? serializeMessage(message) : undefined;
 
-  const originChainName = mp.getChainName(originDomainId);
-  const destinationChainName = mp.getChainName(destinationDomainId);
+  const originChainName = mp.tryGetChainName(originDomainId) || 'Unknown';
+  const destinationChainName = mp.tryGetChainName(destinationDomainId) || 'Unknown';
 
   return (
     <>


### PR DESCRIPTION
use tryGetChainName instead of hard crashing for unknown domains

tested locally

![image](https://github.com/user-attachments/assets/7b6e6de5-c023-4644-af02-e8ccb5a00e0e)
