### PR TITLE
feat: sync url with filters

### DIFF
--- a/src/components/search/SearchFilterBar.tsx
+++ b/src/components/search/SearchFilterBar.tsx
@@ -71,7 +71,7 @@ function ChainSelector({
 
   const multiProvider = useMultiProvider();
 
-  const chainName = value ? multiProvider.getChainName(value) : undefined;
+  const chainName = value ? multiProvider.tryGetChainName(value) : undefined;
   const chainDisplayName = chainName
     ? trimToLength(getChainDisplayName(multiProvider, chainName, true), 12)
     : undefined;

--- a/src/components/search/SearchStates.tsx
+++ b/src/components/search/SearchStates.tsx
@@ -118,3 +118,14 @@ export function SearchUnknownError({ show }: { show: boolean }) {
     />
   );
 }
+
+export function SearchChainError({ show }: { show: boolean }) {
+  return (
+    <SearchError
+      show={show}
+      imgSrc={ErrorIcon}
+      text="Sorry, the origin or destination chain is invalid. Please try choosing another one or cleaning your filters."
+      imgWidth={70}
+    />
+  );
+}

--- a/src/components/search/SearchStates.tsx
+++ b/src/components/search/SearchStates.tsx
@@ -124,7 +124,7 @@ export function SearchChainError({ show }: { show: boolean }) {
     <SearchError
       show={show}
       imgSrc={ErrorIcon}
-      text="Sorry, the origin or destination chain is invalid. Please try choosing another chain or cleaning your filters."
+      text="Sorry, either the origin or the destination chain is invalid. Please choose a different chain or clear your search filters."
       imgWidth={70}
     />
   );

--- a/src/components/search/SearchStates.tsx
+++ b/src/components/search/SearchStates.tsx
@@ -124,7 +124,7 @@ export function SearchChainError({ show }: { show: boolean }) {
     <SearchError
       show={show}
       imgSrc={ErrorIcon}
-      text="Sorry, the origin or destination chain is invalid. Please try choosing another one or cleaning your filters."
+      text="Sorry, the origin or destination chain is invalid. Please try choosing another chain or cleaning your filters."
       imgWidth={70}
     />
   );

--- a/src/features/messages/MessageSearch.tsx
+++ b/src/features/messages/MessageSearch.tsx
@@ -107,6 +107,15 @@ export function MessageSearch() {
   const isAnyMessageFound = isMessagesFound || isPiMessagesFound;
   const messageListResult = isMessagesFound ? messageList : piMessageList;
 
+  // Show message list if there are no errors and filters are valid
+  const showMessageTable =
+    !isAnyError &&
+    isValidInput &&
+    isValidOrigin &&
+    isValidDestination &&
+    isAnyMessageFound &&
+    !!multiProvider;
+
   // Keep url in sync
   useSyncQueryParam({
     [MESSAGE_QUERY_PARAMS.SEARCH]: isValidInput ? sanitizedInput : '',
@@ -140,16 +149,7 @@ export function MessageSearch() {
             onChangeEndTimestamp={setEndTimeFilter}
           />
         </div>
-        <Fade
-          show={
-            !isAnyError &&
-            isValidInput &&
-            isValidOrigin &&
-            isValidDestination &&
-            isAnyMessageFound &&
-            !!multiProvider
-          }
-        >
+        <Fade show={showMessageTable}>
           <MessageTable messageList={messageListResult} isFetching={isAnyFetching} />
         </Fade>
         <SearchFetching

--- a/src/features/messages/MessageSearch.tsx
+++ b/src/features/messages/MessageSearch.tsx
@@ -163,7 +163,7 @@ export function MessageSearch() {
         />
         <SearchUnknownError show={isAnyError && isValidInput} />
         <SearchInvalidError show={!isValidInput} allowAddress={true} />
-        <SearchChainError show={!isValidOrigin || !isValidDestination} />
+        <SearchChainError show={(!isValidOrigin || !isValidDestination) && isValidInput} />
       </Card>
     </>
   );

--- a/src/features/messages/queries/useMessageQuery.ts
+++ b/src/features/messages/queries/useMessageQuery.ts
@@ -24,7 +24,7 @@ export function isValidSearchQuery(input: string) {
 
 export function isValidDomainId(domainId: string | null, multiProvider: MultiProvider) {
   if (!domainId) return false;
-  return !!multiProvider.tryGetDomainId(domainId);
+  return multiProvider.hasChain(domainId);
 }
 
 export function useMessageSearchQuery(

--- a/src/features/messages/queries/useMessageQuery.ts
+++ b/src/features/messages/queries/useMessageQuery.ts
@@ -41,8 +41,9 @@ export function useMessageSearchQuery(
   const isValidInput = !hasInput || isValidSearchQuery(sanitizedInput);
 
   // validating filters
-  const isValidOrigin = isValidDomainId(originChainFilter, multiProvider);
-  const isValidDestination = isValidDomainId(destinationChainFilter, multiProvider);
+  const isValidOrigin = !originChainFilter || isValidDomainId(originChainFilter, multiProvider);
+  const isValidDestination =
+    !destinationChainFilter || isValidDomainId(destinationChainFilter, multiProvider);
 
   // Assemble GraphQL query
   const { query, variables } = buildMessageSearchQuery(

--- a/src/utils/queryParams.ts
+++ b/src/utils/queryParams.ts
@@ -15,28 +15,51 @@ export function getQueryParamString(query: ParsedUrlQuery, key: string, defaultV
 // Use query param form URL
 export function useQueryParam(key: string, defaultVal = '') {
   const router = useRouter();
+
   return getQueryParamString(router.query, key, defaultVal);
 }
 
+export function useMultipleQueryParams(keys: string[]) {
+  const router = useRouter();
+
+  return keys.map((key) => {
+    return getQueryParamString(router.query, key);
+  });
+}
+
 // Keep value in sync with query param in URL
-export function useSyncQueryParam(key: string, value = '') {
+export function useSyncQueryParam(params: Record<string, string>) {
   const router = useRouter();
   const { pathname, query } = router;
   useEffect(() => {
+    let hasChanged = false;
     const newQuery = new URLSearchParams(
       Object.fromEntries(
         Object.entries(query).filter((kv): kv is [string, string] => typeof kv[0] === 'string'),
       ),
     );
-    if (value) newQuery.set(key, value);
-    else newQuery.delete(key);
-    const path = `${pathname}?${newQuery.toString()}`;
-    router
-      .replace(path, undefined, { shallow: true })
-      .catch((e) => logger.error('Error shallow updating url', e));
+    Object.entries(params).forEach(([key, value]) => {
+      if (value) {
+        if (newQuery.get(key) !== value) {
+          newQuery.set(key, value);
+          hasChanged = true;
+        }
+      } else {
+        if (newQuery.has(key)) {
+          newQuery.delete(key);
+          hasChanged = true;
+        }
+      }
+    });
+    if (hasChanged) {
+      const path = `${pathname}?${newQuery.toString()}`;
+      router
+        .replace(path, undefined, { shallow: true })
+        .catch((e) => logger.error('Error shallow updating URL', e));
+    }
     // Must exclude router for next.js shallow routing, otherwise links break:
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key, value]);
+  }, [params]);
 }
 
 // Circumventing Next's router.replace method here because

--- a/src/utils/queryParams.ts
+++ b/src/utils/queryParams.ts
@@ -39,16 +39,12 @@ export function useSyncQueryParam(params: Record<string, string>) {
       ),
     );
     Object.entries(params).forEach(([key, value]) => {
-      if (value) {
-        if (newQuery.get(key) !== value) {
-          newQuery.set(key, value);
-          hasChanged = true;
-        }
-      } else {
-        if (newQuery.has(key)) {
-          newQuery.delete(key);
-          hasChanged = true;
-        }
+      if (value && newQuery.get(key) !== value) {
+        newQuery.set(key, value);
+        hasChanged = true;
+      } else if (!value && newQuery.has(key)) {
+        newQuery.delete(key);
+        hasChanged = true;
       }
     });
     if (hasChanged) {


### PR DESCRIPTION
fixes #145 
- Chain picker and time picker will now sync with the URL. 
- Navigation to this URL will make it so that these filters will remain and be sent to the message query
- For the chains, the keys are `origin` and `destination` and their value will be a `domainId`. Inputting an invalid `domainId` will prompt the `SearchChainError` component to show
- For the time, the keys are `startTime` and `endTime` and their value is a number. The initial load of the values are validated by the function `tryToDecimalNumber()`
- Refactor functions to allow multiple query params. 