### PR TITLE
feat: run checkBytecodeHandle on proxy implementation contract in debugMessage

### DIFF
--- a/src/features/debugger/debugMessage.ts
+++ b/src/features/debugger/debugMessage.ts
@@ -194,12 +194,10 @@ async function debugMessageDelivery(
       destProvider,
       recipient,
     );
-    if (proxyImplementationContract) {
       const bytecodeHasHandle = await tryCheckBytecodeHandle(
         destProvider,
-        proxyImplementationContract,
-      );
-
+        proxyImplementationContract || recipient,
+      )
       if (!bytecodeHasHandle) {
         logger.info('Bytecode does not have function matching handle sig');
         return {

--- a/src/features/debugger/debugMessage.ts
+++ b/src/features/debugger/debugMessage.ts
@@ -194,18 +194,17 @@ async function debugMessageDelivery(
       destProvider,
       recipient,
     );
-      const bytecodeHasHandle = await tryCheckBytecodeHandle(
-        destProvider,
-        proxyImplementationContract || recipient,
-      )
-      if (!bytecodeHasHandle) {
-        logger.info('Bytecode does not have function matching handle sig');
-        return {
-          status: MessageDebugStatus.RecipientNotHandler,
-          description: `Recipient contract should have handle function of signature: ${HANDLE_FUNCTION_SIG}. Check that recipient is not a proxy. Error: ${errorReason}`,
-          calldataDetails,
-        };
-      }
+    const bytecodeHasHandle = await tryCheckBytecodeHandle(
+      destProvider,
+      proxyImplementationContract || recipient,
+    );
+    if (!bytecodeHasHandle) {
+      logger.info('Bytecode does not have function matching handle sig');
+      return {
+        status: MessageDebugStatus.RecipientNotHandler,
+        description: `Recipient contract should have handle function of signature: ${HANDLE_FUNCTION_SIG}. Check that recipient is not a proxy. Error: ${errorReason}`,
+        calldataDetails,
+      };
     }
 
     const icaCallErr = await tryDebugIcaMsg(sender, recipient, body, originDomain, destProvider);

--- a/src/features/debugger/debugMessage.ts
+++ b/src/features/debugger/debugMessage.ts
@@ -202,7 +202,7 @@ async function debugMessageDelivery(
       logger.info('Bytecode does not have function matching handle sig');
       return {
         status: MessageDebugStatus.RecipientNotHandler,
-        description: `Recipient contract should have handle function of signature: ${HANDLE_FUNCTION_SIG}. Check that recipient is not a proxy. Error: ${errorReason}`,
+        description: `Recipient contract should have handle function of signature: ${HANDLE_FUNCTION_SIG}. Error: ${errorReason}`,
         calldataDetails,
       };
     }


### PR DESCRIPTION
fixes #150 

- Now runs `tryCheckBytecodeHandle` only for real contracts
- Checks if given contract is a proxy, if it is try to get proxy implementation contract
- When an `proxyImplementationContract` is returned runs `bytecode` check for it, otherwise just runs `bytecode` check for the recipient