### PR TITLE
chore: add treasuretopaz to debug ignored chains

### DIFF
--- a/src/consts/config.ts
+++ b/src/consts/config.ts
@@ -22,4 +22,4 @@ export const config: Config = Object.freeze({
 // Based on https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/infra/config/environments/testnet4/agent.ts
 export const unscrapedChainsInDb = ['proteustestnet', 'viction'];
 
-export const debugIgnoredChains = ['treasure'];
+export const debugIgnoredChains = ['treasure', 'treasuretopaz'];


### PR DESCRIPTION
Same fix as #149, add Treasure Topaz Testnet to debug ignored chain until further notice