### PR TITLE
feat: use chain name instead of domainId for filters

### DIFF
--- a/src/components/search/SearchFilterBar.tsx
+++ b/src/components/search/SearchFilterBar.tsx
@@ -71,9 +71,8 @@ function ChainSelector({
 
   const multiProvider = useMultiProvider();
 
-  const chainName = value ? multiProvider.tryGetChainName(value) : undefined;
-  const chainDisplayName = chainName
-    ? trimToLength(getChainDisplayName(multiProvider, chainName, true), 12)
+  const chainDisplayName = value
+    ? trimToLength(getChainDisplayName(multiProvider, value, true), 12)
     : undefined;
 
   const onClickChain = (c: ChainMetadata) => {

--- a/src/components/search/SearchFilterBar.tsx
+++ b/src/components/search/SearchFilterBar.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { useState } from 'react';
 
-import { ChainMetadata, getDomainId } from '@hyperlane-xyz/sdk';
+import { ChainMetadata } from '@hyperlane-xyz/sdk';
 import { trimToLength } from '@hyperlane-xyz/utils';
 import {
   ChevronIcon,
@@ -77,7 +77,7 @@ function ChainSelector({
     : undefined;
 
   const onClickChain = (c: ChainMetadata) => {
-    onChangeValue(getDomainId(c).toString());
+    onChangeValue(c.name);
     close();
   };
 

--- a/src/features/messages/MessageSearch.tsx
+++ b/src/features/messages/MessageSearch.tsx
@@ -126,9 +126,6 @@ export function MessageSearch() {
     [MESSAGE_QUERY_PARAMS.END_TIME]: endTimeFilter !== null ? String(endTimeFilter) : '',
   });
 
-  console.log('isValidOrigin', isValidOrigin);
-  console.log('isValidDestination', isValidDestination);
-
   return (
     <>
       <SearchBar

--- a/src/features/messages/MessageSearch.tsx
+++ b/src/features/messages/MessageSearch.tsx
@@ -126,6 +126,9 @@ export function MessageSearch() {
     [MESSAGE_QUERY_PARAMS.END_TIME]: endTimeFilter !== null ? String(endTimeFilter) : '',
   });
 
+  console.log('isValidOrigin', isValidOrigin);
+  console.log('isValidDestination', isValidDestination);
+
   return (
     <>
       <SearchBar

--- a/src/features/messages/queries/build.ts
+++ b/src/features/messages/queries/build.ts
@@ -64,15 +64,15 @@ export function buildMessageQuery(
 
 export function buildMessageSearchQuery(
   searchInput: string,
-  originFilter: string | null,
-  destFilter: string | null,
+  originFilter: number | null,
+  destFilter: number | null,
   startTimeFilter: number | null,
   endTimeFilter: number | null,
   limit: number,
   useStub = false,
 ) {
-  const originChains = originFilter ? originFilter.split(',') : undefined;
-  const destinationChains = destFilter ? destFilter.split(',') : undefined;
+  const originChains = originFilter ? originFilter.toString().split(',') : undefined;
+  const destinationChains = destFilter ? destFilter.toString().split(',') : undefined;
   const startTime = startTimeFilter ? adjustToUtcTime(startTimeFilter) : undefined;
   const endTime = endTimeFilter ? adjustToUtcTime(endTimeFilter) : undefined;
   const variables = {

--- a/src/features/messages/queries/build.ts
+++ b/src/features/messages/queries/build.ts
@@ -64,15 +64,19 @@ export function buildMessageQuery(
 
 export function buildMessageSearchQuery(
   searchInput: string,
-  originFilter: number | null,
-  destFilter: number | null,
+  originDomainIdFilter: number | null,
+  destDomainIdFilter: number | null,
   startTimeFilter: number | null,
   endTimeFilter: number | null,
   limit: number,
   useStub = false,
 ) {
-  const originChains = originFilter ? originFilter.toString().split(',') : undefined;
-  const destinationChains = destFilter ? destFilter.toString().split(',') : undefined;
+  const originChains = originDomainIdFilter
+    ? originDomainIdFilter.toString().split(',')
+    : undefined;
+  const destinationChains = destDomainIdFilter
+    ? destDomainIdFilter.toString().split(',')
+    : undefined;
   const startTime = startTimeFilter ? adjustToUtcTime(startTimeFilter) : undefined;
   const endTime = endTimeFilter ? adjustToUtcTime(endTimeFilter) : undefined;
   const variables = {
@@ -91,8 +95,8 @@ export function buildMessageSearchQuery(
       `q${i}: message_view(
     where: {
       _and: [
-        ${originFilter ? '{origin_domain_id: {_in: $originChains}},' : ''}
-        ${destFilter ? '{destination_domain_id: {_in: $destinationChains}},' : ''}
+        ${originDomainIdFilter ? '{origin_domain_id: {_in: $originChains}},' : ''}
+        ${destinationChains ? '{destination_domain_id: {_in: $destinationChains}},' : ''}
         ${startTimeFilter ? '{send_occurred_at: {_gte: $startTime}},' : ''}
         ${endTimeFilter ? '{send_occurred_at: {_lte: $endTime}},' : ''}
         ${whereClause}

--- a/src/features/messages/queries/build.ts
+++ b/src/features/messages/queries/build.ts
@@ -71,12 +71,8 @@ export function buildMessageSearchQuery(
   limit: number,
   useStub = false,
 ) {
-  const originChains = originDomainIdFilter
-    ? originDomainIdFilter.toString().split(',')
-    : undefined;
-  const destinationChains = destDomainIdFilter
-    ? destDomainIdFilter.toString().split(',')
-    : undefined;
+  const originChains = originDomainIdFilter ? [originDomainIdFilter] : undefined;
+  const destinationChains = destDomainIdFilter ? [destDomainIdFilter] : undefined;
   const startTime = startTimeFilter ? adjustToUtcTime(startTimeFilter) : undefined;
   const endTime = endTimeFilter ? adjustToUtcTime(endTimeFilter) : undefined;
   const variables = {
@@ -96,7 +92,7 @@ export function buildMessageSearchQuery(
     where: {
       _and: [
         ${originDomainIdFilter ? '{origin_domain_id: {_in: $originChains}},' : ''}
-        ${destinationChains ? '{destination_domain_id: {_in: $destinationChains}},' : ''}
+        ${destDomainIdFilter ? '{destination_domain_id: {_in: $destinationChains}},' : ''}
         ${startTimeFilter ? '{send_occurred_at: {_gte: $startTime}},' : ''}
         ${endTimeFilter ? '{send_occurred_at: {_lte: $endTime}},' : ''}
         ${whereClause}

--- a/src/features/messages/queries/useMessageQuery.ts
+++ b/src/features/messages/queries/useMessageQuery.ts
@@ -5,7 +5,6 @@ import { useMultiProvider } from '../../../store';
 import { MessageStatus } from '../../../types';
 import { useScrapedDomains } from '../../chains/queries/useScrapedChains';
 
-import { MultiProvider } from '@hyperlane-xyz/sdk';
 import { useInterval } from '@hyperlane-xyz/widgets';
 import { MessageIdentifierType, buildMessageQuery, buildMessageSearchQuery } from './build';
 import { searchValueToPostgresBytea } from './encoding';
@@ -20,11 +19,6 @@ const SEARCH_QUERY_LIMIT = 50;
 export function isValidSearchQuery(input: string) {
   if (!input) return false;
   return !!searchValueToPostgresBytea(input);
-}
-
-export function isValidDomainId(domainId: string | null, multiProvider: MultiProvider) {
-  if (!domainId) return false;
-  return multiProvider.hasChain(domainId);
 }
 
 export function useMessageSearchQuery(

--- a/src/features/messages/queries/useMessageQuery.ts
+++ b/src/features/messages/queries/useMessageQuery.ts
@@ -40,16 +40,21 @@ export function useMessageSearchQuery(
   const hasInput = !!sanitizedInput;
   const isValidInput = !hasInput || isValidSearchQuery(sanitizedInput);
 
+  // Get chains domainId
+  const originDomainId = originChainFilter ? multiProvider.tryGetDomainId(originChainFilter) : null;
+  const destDomainId = destinationChainFilter
+    ? multiProvider.tryGetDomainId(destinationChainFilter)
+    : null;
+
   // validating filters
-  const isValidOrigin = !originChainFilter || isValidDomainId(originChainFilter, multiProvider);
-  const isValidDestination =
-    !destinationChainFilter || isValidDomainId(destinationChainFilter, multiProvider);
+  const isValidOrigin = !originChainFilter || originDomainId !== null;
+  const isValidDestination = !destinationChainFilter || destDomainId !== null;
 
   // Assemble GraphQL query
   const { query, variables } = buildMessageSearchQuery(
     sanitizedInput,
-    isValidOrigin ? originChainFilter : null,
-    isValidDestination ? destinationChainFilter : null,
+    isValidOrigin ? originDomainId : null,
+    isValidDestination ? destDomainId : null,
     startTimeFilter,
     endTimeFilter,
     hasInput ? SEARCH_QUERY_LIMIT : LATEST_QUERY_LIMIT,

--- a/src/features/messages/queries/useMessageQuery.ts
+++ b/src/features/messages/queries/useMessageQuery.ts
@@ -23,8 +23,8 @@ export function isValidSearchQuery(input: string) {
 
 export function useMessageSearchQuery(
   sanitizedInput: string,
-  originChainFilter: string | null,
-  destinationChainFilter: string | null,
+  originChainNameFilter: string | null,
+  destinationChainNameFilter: string | null,
   startTimeFilter: number | null,
   endTimeFilter: number | null,
 ) {
@@ -35,14 +35,16 @@ export function useMessageSearchQuery(
   const isValidInput = !hasInput || isValidSearchQuery(sanitizedInput);
 
   // Get chains domainId
-  const originDomainId = originChainFilter ? multiProvider.tryGetDomainId(originChainFilter) : null;
-  const destDomainId = destinationChainFilter
-    ? multiProvider.tryGetDomainId(destinationChainFilter)
+  const originDomainId = originChainNameFilter
+    ? multiProvider.tryGetDomainId(originChainNameFilter)
+    : null;
+  const destDomainId = destinationChainNameFilter
+    ? multiProvider.tryGetDomainId(destinationChainNameFilter)
     : null;
 
   // validating filters
-  const isValidOrigin = !originChainFilter || originDomainId !== null;
-  const isValidDestination = !destinationChainFilter || destDomainId !== null;
+  const isValidOrigin = !originChainNameFilter || originDomainId !== null;
+  const isValidDestination = !destinationChainNameFilter || destDomainId !== null;
 
   // Assemble GraphQL query
   const { query, variables } = buildMessageSearchQuery(
@@ -72,8 +74,8 @@ export function useMessageSearchQuery(
   // Filter recent messages during DB backfilling period
   // TODO remove this once backfilling is complete
   const hasFilter = !!(
-    originChainFilter ||
-    destinationChainFilter ||
+    originChainNameFilter ||
+    destinationChainNameFilter ||
     startTimeFilter ||
     endTimeFilter
   );


### PR DESCRIPTION
Now uses chain name instead of `domainId` as URL filter

- Update `ChainSelector` onChange function to update value with chain name instead of `domainId`
- Update logic for `useMessageSearchQuery` to get `domainId` from chain name 

fixes #170 

