### PR TITLE
fix: error in the Tailwind CSS class 

### DIFF
--- a/src/features/messages/cards/TransactionCard.tsx
+++ b/src/features/messages/cards/TransactionCard.tsx
@@ -309,7 +309,7 @@ function CallDataModal({ debugResult }: { debugResult?: MessageDebugResult }) {
           <p className="text-sm font-light">
             {`The last step of message delivery is the recipient contract's 'handle' function. If the handle is reverting, try debugging it with `}
             <a
-              className={`${styles.textLink} all:text-blue-500`}
+              className={`${styles.textLink} hover:text-blue-500`}
               href={links.tenderlySimDocs}
               target="_blank"
               rel="noopener noreferrer"

--- a/src/utils/queryParams.ts
+++ b/src/utils/queryParams.ts
@@ -59,7 +59,7 @@ export function useSyncQueryParam(params: Record<string, string>) {
 }
 
 // Circumventing Next's router.replace method here because
-// it's async and causes race conditions btwn components.
+// it's async and causes race conditions between components.
 // This will only modify the url but not trigger any routing
 export function replacePathParam(key: string, val: string) {
   try {


### PR DESCRIPTION
The "all" prefix is not a valid modifier in Tailwind CSS