### PR TITLE
fix: correctly return chain display name

### DIFF
--- a/src/features/chains/utils.ts
+++ b/src/features/chains/utils.ts
@@ -26,7 +26,7 @@ export function getChainDisplayName(
   const metadata = multiProvider.tryGetChainMetadata(chainName || 0);
   if (!metadata) return fallbackToId && chainName ? chainName : 'Unknown';
   const displayName = shortName ? metadata.displayNameShort : metadata.displayName;
-  return toTitleCase(displayName || metadata.displayName || metadata.name);
+  return displayName || metadata.displayName || toTitleCase(metadata.name);
 }
 
 export function getChainEnvironment(multiProvider: MultiProvider, domainId: DomainId) {


### PR DESCRIPTION
fix: correctly return chain display name
- we were previously converting all names `toTitleCase`, when we only need to do that if we fallback to the standard chain name
- displayName / displayNameShort should be displayed as-is

before:
<img width="933" alt="image" src="https://github.com/user-attachments/assets/405f2fe2-8836-4781-8116-f2ec4638d954" />

after:
<img width="941" alt="image" src="https://github.com/user-attachments/assets/3eeb0809-d98c-4e76-bdfe-9ea6bd2cc393" />
