### PR TITLE
feat: link for block explorer addresses

### DIFF
--- a/src/features/messages/cards/KeyValueRow.tsx
+++ b/src/features/messages/cards/KeyValueRow.tsx
@@ -1,5 +1,5 @@
 import { isZeroish } from '@hyperlane-xyz/utils';
-import { CopyButton } from '@hyperlane-xyz/widgets';
+import { BoxArrowIcon, CopyButton } from '@hyperlane-xyz/widgets';
 
 interface Props {
   label: string;
@@ -11,6 +11,8 @@ interface Props {
   blurValue?: boolean;
   classes?: string;
   allowZeroish?: boolean;
+  link?: string | null;
+  copyButtonClasses?: string | null;
 }
 
 export function KeyValueRow({
@@ -23,6 +25,8 @@ export function KeyValueRow({
   blurValue,
   classes,
   allowZeroish = false,
+  link,
+  copyButtonClasses = '',
 }: Props) {
   const useFallbackVal = isZeroish(display) && !allowZeroish;
   return (
@@ -33,8 +37,22 @@ export function KeyValueRow({
         {subDisplay && !useFallbackVal && <span className="ml-2 text-xs">{subDisplay}</span>}
       </div>
       {showCopy && !useFallbackVal && (
-        <CopyButton copyValue={display} width={13} height={13} className="ml-1.5 opacity-60" />
+        <CopyButton
+          copyValue={display}
+          width={13}
+          height={13}
+          className={`ml-1.5 opacity-60 ${copyButtonClasses}`}
+        />
       )}
+      {link && <LinkIcon href={link} />}
     </div>
+  );
+}
+
+function LinkIcon({ href }: { href: string }) {
+  return (
+    <a target="_blank" rel="noopener noreferrer" href={href}>
+      <BoxArrowIcon width={13} height={13} className="ml-1.5" />
+    </a>
   );
 }

--- a/src/features/messages/cards/WarpTransferDetailsCard.tsx
+++ b/src/features/messages/cards/WarpTransferDetailsCard.tsx
@@ -7,13 +7,16 @@ import {
 } from '@hyperlane-xyz/utils';
 import { Tooltip } from '@hyperlane-xyz/widgets';
 import Image from 'next/image';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Card } from '../../../components/layout/Card';
 import SendMoney from '../../../images/icons/send-money.svg';
 import { useMultiProvider, useStore } from '../../../store';
 import { Message, WarpRouteChainAddressMap, WarpRouteDetails } from '../../../types';
 import { logger } from '../../../utils/logger';
 import { getTokenFromWarpRouteChainAddressMap } from '../../../utils/token';
+import { tryGetBlockExplorerAddressUrl } from '../../../utils/url';
 import { KeyValueRow } from './KeyValueRow';
+import { BlockExplorerAddressUrls } from './types';
 
 interface Props {
   message: Message;
@@ -25,7 +28,42 @@ export function WarpTransferDetailsCard({ message, blur }: Props) {
   const { warpRouteChainAddressMap } = useStore((s) => ({
     warpRouteChainAddressMap: s.warpRouteChainAddressMap,
   }));
-  const warpRouteDetails = parseWarpRouteDetails(message, warpRouteChainAddressMap, multiProvider);
+  const warpRouteDetails = useMemo(
+    () => parseWarpRouteDetails(message, warpRouteChainAddressMap, multiProvider),
+    [message, warpRouteChainAddressMap, multiProvider],
+  );
+  const [blockExplorerAddressUrls, setBlockExplorerAddressUrls] = useState<
+    BlockExplorerAddressUrls | undefined
+  >(undefined);
+
+  const getBlockExplorerLinks = useCallback(async (): Promise<
+    BlockExplorerAddressUrls | undefined
+  > => {
+    if (!warpRouteDetails) return undefined;
+
+    const originToken = await tryGetBlockExplorerAddressUrl(
+      multiProvider,
+      message.originChainId,
+      warpRouteDetails.originTokenAddress,
+    );
+    const destinationToken = await tryGetBlockExplorerAddressUrl(
+      multiProvider,
+      message.destinationChainId,
+      warpRouteDetails.destinationTokenAddress,
+    );
+    const transferRecipient = await tryGetBlockExplorerAddressUrl(
+      multiProvider,
+      message.destinationChainId,
+      warpRouteDetails.transferRecipient,
+    );
+    return { destinationToken, originToken, transferRecipient };
+  }, [message, multiProvider, warpRouteDetails]);
+
+  useEffect(() => {
+    getBlockExplorerLinks()
+      .then((urls) => setBlockExplorerAddressUrls(urls))
+      .catch(() => setBlockExplorerAddressUrls(undefined));
+  }, [getBlockExplorerLinks]);
 
   if (!warpRouteDetails) return null;
 
@@ -63,16 +101,18 @@ export function WarpTransferDetailsCard({ message, blur }: Props) {
           labelWidth="w-20 sm:w-32"
           display={originTokenAddress}
           displayWidth="w-64 sm:w-96"
-          showCopy={true}
           blurValue={blur}
+          link={blockExplorerAddressUrls?.originToken}
+          showCopy
         />
         <KeyValueRow
           label="Destination token:"
           labelWidth="w-20 sm:w-32"
           display={destinationTokenAddress}
           displayWidth="w-64 sm:w-96"
-          showCopy={true}
           blurValue={blur}
+          link={blockExplorerAddressUrls?.destinationToken}
+          showCopy
         />
         <KeyValueRow
           label="Transfer recipient:"
@@ -80,6 +120,7 @@ export function WarpTransferDetailsCard({ message, blur }: Props) {
           display={transferRecipient}
           displayWidth="w-64 sm:w-96"
           blurValue={blur}
+          link={blockExplorerAddressUrls?.transferRecipient}
           showCopy
         />
       </div>

--- a/src/features/messages/cards/types.ts
+++ b/src/features/messages/cards/types.ts
@@ -1,0 +1,7 @@
+export type BlockExplorerAddressUrls = {
+  originToken?: string | null;
+  destinationToken?: string | null;
+  transferRecipient?: string | null;
+  sender?: string | null;
+  recipient?: string | null;
+};

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,12 @@
+import { ChainNameOrId, MultiProvider } from '@hyperlane-xyz/sdk';
+import BigNumber from 'bignumber.js';
+
+export async function tryGetBlockExplorerAddressUrl(
+  multiProvider: MultiProvider,
+  chain: ChainNameOrId,
+  address: string,
+) {
+  return address && !new BigNumber(address).isZero()
+    ? await multiProvider.tryGetExplorerAddressUrl(chain, address)
+    : null;
+}


### PR DESCRIPTION
This PR adds a link for some of addresses that are in the Message Details and Warp Transfer Details section

- Adds link to block explorer for certain addresses
- Add LinkIcon to `KeyValueRow` component
- Add utils function `tryGetBlockExplorerAddressUrl` to retrieve block explorer address URL from `multiprovider`