### PR TITLE
fix: decimals amount for warp transfer detail cards

### DIFF
--- a/src/features/messages/cards/WarpTransferDetailsCard.tsx
+++ b/src/features/messages/cards/WarpTransferDetailsCard.tsx
@@ -171,7 +171,10 @@ export function parseWarpRouteDetails(
     );
 
     return {
-      amount: fromWei(parsedMessage.amount.toString(), originToken.decimals || 18),
+      amount: fromWei(
+        parsedMessage.amount.toString(),
+        Math.max(originToken.decimals, destinationToken.decimals) || 18,
+      ),
       transferRecipient: address,
       originTokenAddress: to,
       originTokenSymbol: originToken.symbol,


### PR DESCRIPTION
Fixed an issue where some warp routes had different decimals, which caused the amount field to display incorrectly because it used origin decimals instead, currently we don't have a great way of representing remote decimals but using the max between the chains in the warp route would proof mostly correct (not guaranteed)

before:
![image](https://github.com/user-attachments/assets/2d633905-755b-470b-b776-44bc75c1a8cb)
after:
![image](https://github.com/user-attachments/assets/36377d7a-1588-4b5e-a2fb-367fce3ac75a)
