### PR TITLE
feat: filter out testnet messages by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hyperlane-xyz/explorer",
   "description": "An interchain explorer for the Hyperlane protocol and network.",
-  "version": "7.1.0",
+  "version": "12.0.0",
   "author": "J M Rossy",
   "dependencies": {
     "@headlessui/react": "^2.2.0",

--- a/src/features/messages/queries/build.ts
+++ b/src/features/messages/queries/build.ts
@@ -104,8 +104,6 @@ export function buildMessageSearchQuery(
     mainnetDomainIds,
   );
 
-  console.log('destinationDomainWhereClause', destinationDomainWhereClause);
-
   // Due to DB performance issues, we cannot use an `_or` clause
   // Instead, each where clause for the search will be its own query
   const queries = whereClauses.map(

--- a/src/features/messages/queries/useMessageQuery.ts
+++ b/src/features/messages/queries/useMessageQuery.ts
@@ -3,7 +3,7 @@ import { useQuery } from 'urql';
 
 import { useMultiProvider } from '../../../store';
 import { MessageStatus } from '../../../types';
-import { useScrapedDomains } from '../../chains/queries/useScrapedChains';
+import { useScrapedChains, useScrapedDomains } from '../../chains/queries/useScrapedChains';
 
 import { useInterval } from '@hyperlane-xyz/widgets';
 import { MessageIdentifierType, buildMessageQuery, buildMessageSearchQuery } from './build';
@@ -30,6 +30,9 @@ export function useMessageSearchQuery(
 ) {
   const { scrapedDomains: scrapedChains } = useScrapedDomains();
   const multiProvider = useMultiProvider();
+  const { chains } = useScrapedChains(multiProvider);
+  const mainnetChains = Object.values(chains).filter((chain) => !chain.isTestnet);
+  console.log('mainnet', mainnetChains);
 
   const hasInput = !!sanitizedInput;
   const isValidInput = !hasInput || isValidSearchQuery(sanitizedInput);
@@ -55,6 +58,7 @@ export function useMessageSearchQuery(
     endTimeFilter,
     hasInput ? SEARCH_QUERY_LIMIT : LATEST_QUERY_LIMIT,
     true,
+    mainnetChains.map((chain) => chain.domainId),
   );
 
   // Execute query

--- a/src/features/messages/queries/useMessageQuery.ts
+++ b/src/features/messages/queries/useMessageQuery.ts
@@ -31,8 +31,9 @@ export function useMessageSearchQuery(
   const { scrapedDomains: scrapedChains } = useScrapedDomains();
   const multiProvider = useMultiProvider();
   const { chains } = useScrapedChains(multiProvider);
-  const mainnetChains = Object.values(chains).filter((chain) => !chain.isTestnet);
-  console.log('mainnet', mainnetChains);
+  const mainnetDomainIds = Object.values(chains)
+    .filter((chain) => !chain.isTestnet)
+    .map((chain) => chain.domainId);
 
   const hasInput = !!sanitizedInput;
   const isValidInput = !hasInput || isValidSearchQuery(sanitizedInput);
@@ -58,7 +59,7 @@ export function useMessageSearchQuery(
     endTimeFilter,
     hasInput ? SEARCH_QUERY_LIMIT : LATEST_QUERY_LIMIT,
     true,
-    mainnetChains.map((chain) => chain.domainId),
+    mainnetDomainIds,
   );
 
   // Execute query


### PR DESCRIPTION
close #195 

- Remove testnet message by default
- Now origin and destination will filter by mainnet chains if no filters are provided
- Bump `package.json` version in accordance to `hyperlane` packages upgrade

Running the queries locally show that they still get result very fast regardless of the amount of chains set (around 130 for both origin and destination)

Speed seems to run between: 90 ~ 360ms, where the highest spike occurs when the query is first fetched or if there hasn't been a refetch in a while, in comparison to the current production build where query last around 90~200ms