### PR TITLE
feat: warped token row

### DIFF
--- a/src/features/deliveryStatus/useMessageDeliveryStatus.tsx
+++ b/src/features/deliveryStatus/useMessageDeliveryStatus.tsx
@@ -1,16 +1,13 @@
+import { MultiProvider } from '@hyperlane-xyz/sdk';
+import { errorToString } from '@hyperlane-xyz/utils';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { toast } from 'react-toastify';
-
-import { MultiProvider } from '@hyperlane-xyz/sdk';
-import { errorToString } from '@hyperlane-xyz/utils';
-
 import { useReadyMultiProvider, useRegistry, useStore } from '../../store';
 import { Message, MessageStatus } from '../../types';
 import { logger } from '../../utils/logger';
 import { MissingChainConfigToast } from '../chains/MissingChainConfigToast';
 import { isEvmChain } from '../chains/utils';
-
 import { fetchDeliveryStatus } from './fetchDeliveryStatus';
 
 export function useMessageDeliveryStatus({

--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -21,9 +21,7 @@ export function MessageTable({
   isFetching: boolean;
 }) {
   const multiProvider = useMultiProvider();
-  const { warpRouteChainAddressMap } = useStore((s) => ({
-    warpRouteChainAddressMap: s.warpRouteChainAddressMap,
-  }));
+  const warpRouteChainAddressMap = useStore((s) => s.warpRouteChainAddressMap);
 
   return (
     <table className="mb-1 w-full">

--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useMemo } from 'react';
 
 import { MultiProvider } from '@hyperlane-xyz/sdk';
 import { shortenAddress } from '@hyperlane-xyz/utils';
@@ -8,11 +8,13 @@ import { shortenAddress } from '@hyperlane-xyz/utils';
 import { ChainLogo } from '../../components/icons/ChainLogo';
 import CheckmarkIcon from '../../images/icons/checkmark-circle.svg';
 import ErrorIcon from '../../images/icons/error-circle.svg';
-import { useMultiProvider } from '../../store';
-import { MessageStatus, MessageStub } from '../../types';
+import { useMultiProvider, useStore } from '../../store';
+import { MessageStatus, MessageStub, WarpRouteChainAddressMap } from '../../types';
 import { getHumanReadableTimeString } from '../../utils/time';
 import { getChainDisplayName } from '../chains/utils';
 
+import { Tooltip } from '@hyperlane-xyz/widgets';
+import { parseWarpRouteDetails } from './cards/WarpTransferDetailsCard';
 import { serializeMessage } from './utils';
 
 export function MessageTable({
@@ -23,6 +25,9 @@ export function MessageTable({
   isFetching: boolean;
 }) {
   const multiProvider = useMultiProvider();
+  const { warpRouteChainAddressMap } = useStore((s) => ({
+    warpRouteChainAddressMap: s.warpRouteChainAddressMap,
+  }));
 
   return (
     <table className="mb-1 w-full">
@@ -33,6 +38,7 @@ export function MessageTable({
           <th className={`${styles.header} hidden sm:table-cell`}>Sender</th>
           <th className={`${styles.header} hidden sm:table-cell`}>Recipient</th>
           <th className={`${styles.header} hidden lg:table-cell`}>Origin Tx</th>
+          <th className={`${styles.header} hidden sm:table-cell`}>Warped Token</th>
           <th className={styles.header}>Time sent</th>
         </tr>
       </thead>
@@ -44,7 +50,11 @@ export function MessageTable({
               isFetching && 'blur-xs'
             } transition-all duration-500`}
           >
-            <MessageSummaryRow message={m} mp={multiProvider} />
+            <MessageSummaryRow
+              message={m}
+              mp={multiProvider}
+              warpRouteChainAddressMap={warpRouteChainAddressMap}
+            />
           </tr>
         ))}
       </tbody>
@@ -52,7 +62,15 @@ export function MessageTable({
   );
 }
 
-export function MessageSummaryRow({ message, mp }: { message: MessageStub; mp: MultiProvider }) {
+export function MessageSummaryRow({
+  message,
+  mp,
+  warpRouteChainAddressMap,
+}: {
+  message: MessageStub;
+  mp: MultiProvider;
+  warpRouteChainAddressMap: WarpRouteChainAddressMap;
+}) {
   const { msgId, status, sender, recipient, originDomainId, destinationDomainId, origin } = message;
 
   let statusIcon = undefined;
@@ -69,6 +87,10 @@ export function MessageSummaryRow({ message, mp }: { message: MessageStub; mp: M
 
   const originChainName = mp.tryGetChainName(originDomainId) || 'Unknown';
   const destinationChainName = mp.tryGetChainName(destinationDomainId) || 'Unknown';
+  const warpRouteDetails = useMemo(
+    () => parseWarpRouteDetails(message, warpRouteChainAddressMap, mp),
+    [message, warpRouteChainAddressMap, mp],
+  );
 
   return (
     <>
@@ -95,6 +117,22 @@ export function MessageSummaryRow({ message, mp }: { message: MessageStub; mp: M
         aClasses={styles.valueTruncated}
       >
         {shortenAddress(origin.hash)}
+      </LinkCell>
+      <LinkCell
+        id={msgId}
+        base64={base64}
+        aClasses={styles.valueTruncated}
+        tdClasses="hidden sm:table-cell"
+      >
+        {warpRouteDetails ? (
+          warpRouteDetails.originTokenSymbol
+        ) : (
+          <Tooltip
+            content="Unable to derive token from transfer. Message might not be a Hyperlane warp route token transfer."
+            id="no-token-info"
+            tooltipClassName="sm:max-w-[550px]"
+          />
+        )}
       </LinkCell>
       <LinkCell id={msgId} base64={base64} aClasses={styles.valueTruncated}>
         {getHumanReadableTimeString(origin.timestamp)}

--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -126,7 +126,7 @@ export function MessageSummaryRow({
           <Tooltip
             content="Unable to derive token from transfer. Message might not be a Hyperlane warp route token transfer."
             id="no-token-info"
-            tooltipClassName="sm:max-w-[550px]"
+            tooltipClassName="whitespace-normal break-words text-left"
           />
         )}
       </LinkCell>

--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -1,10 +1,9 @@
+import { MultiProvider } from '@hyperlane-xyz/sdk';
+import { shortenAddress } from '@hyperlane-xyz/utils';
+import { Tooltip } from '@hyperlane-xyz/widgets';
 import Image from 'next/image';
 import Link from 'next/link';
 import { PropsWithChildren, useMemo } from 'react';
-
-import { MultiProvider } from '@hyperlane-xyz/sdk';
-import { shortenAddress } from '@hyperlane-xyz/utils';
-
 import { ChainLogo } from '../../components/icons/ChainLogo';
 import CheckmarkIcon from '../../images/icons/checkmark-circle.svg';
 import ErrorIcon from '../../images/icons/error-circle.svg';
@@ -12,10 +11,7 @@ import { useMultiProvider, useStore } from '../../store';
 import { MessageStatus, MessageStub, WarpRouteChainAddressMap } from '../../types';
 import { getHumanReadableTimeString } from '../../utils/time';
 import { getChainDisplayName } from '../chains/utils';
-
-import { Tooltip } from '@hyperlane-xyz/widgets';
-import { parseWarpRouteDetails } from './cards/WarpTransferDetailsCard';
-import { serializeMessage } from './utils';
+import { parseWarpRouteMessageDetails, serializeMessage } from './utils';
 
 export function MessageTable({
   messageList,
@@ -88,7 +84,7 @@ export function MessageSummaryRow({
   const originChainName = mp.tryGetChainName(originDomainId) || 'Unknown';
   const destinationChainName = mp.tryGetChainName(destinationDomainId) || 'Unknown';
   const warpRouteDetails = useMemo(
-    () => parseWarpRouteDetails(message, warpRouteChainAddressMap, mp),
+    () => parseWarpRouteMessageDetails(message, warpRouteChainAddressMap, mp),
     [message, warpRouteChainAddressMap, mp],
   );
 

--- a/src/features/messages/cards/WarpTransferDetailsCard.tsx
+++ b/src/features/messages/cards/WarpTransferDetailsCard.tsx
@@ -17,9 +17,7 @@ interface Props {
 
 export function WarpTransferDetailsCard({ message, blur }: Props) {
   const multiProvider = useMultiProvider();
-  const { warpRouteChainAddressMap } = useStore((s) => ({
-    warpRouteChainAddressMap: s.warpRouteChainAddressMap,
-  }));
+  const warpRouteChainAddressMap = useStore((s) => s.warpRouteChainAddressMap);
   const warpRouteDetails = useMemo(
     () => parseWarpRouteMessageDetails(message, warpRouteChainAddressMap, multiProvider),
     [message, warpRouteChainAddressMap, multiProvider],

--- a/src/features/messages/cards/WarpTransferDetailsCard.tsx
+++ b/src/features/messages/cards/WarpTransferDetailsCard.tsx
@@ -11,7 +11,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Card } from '../../../components/layout/Card';
 import SendMoney from '../../../images/icons/send-money.svg';
 import { useMultiProvider, useStore } from '../../../store';
-import { Message, WarpRouteChainAddressMap, WarpRouteDetails } from '../../../types';
+import { Message, MessageStub, WarpRouteChainAddressMap, WarpRouteDetails } from '../../../types';
 import { logger } from '../../../utils/logger';
 import { getTokenFromWarpRouteChainAddressMap } from '../../../utils/token';
 import { tryGetBlockExplorerAddressUrl } from '../../../utils/url';
@@ -129,7 +129,7 @@ export function WarpTransferDetailsCard({ message, blur }: Props) {
 }
 
 export function parseWarpRouteDetails(
-  message: Message,
+  message: Message | MessageStub,
   warpRouteChainAddressMap: WarpRouteChainAddressMap,
   multiProvider: MultiProvider,
 ): WarpRouteDetails | undefined {

--- a/src/features/messages/pi-queries/fetchPiChainMessages.test.ts
+++ b/src/features/messages/pi-queries/fetchPiChainMessages.test.ts
@@ -1,9 +1,7 @@
 import { GithubRegistry, chainAddresses, chainMetadata } from '@hyperlane-xyz/registry';
 import { ChainMetadata, MultiProvider } from '@hyperlane-xyz/sdk';
-
 import { config } from '../../../consts/config';
 import { Message, MessageStatus } from '../../../types';
-
 import { fetchMessagesFromPiChain } from './fetchPiChainMessages';
 
 // NOTE: THE SEPOLIA MESSAGE MAY NEED TO BE UPDATED ON OCCASION AS IT GETS TOO OLD

--- a/src/features/messages/queries/fragments.ts
+++ b/src/features/messages/queries/fragments.ts
@@ -19,16 +19,18 @@ export const messageStubFragment = `
   origin_tx_id
   origin_tx_hash
   origin_tx_sender
+  origin_tx_recipient
   destination_chain_id
   destination_domain_id
   destination_tx_id
   destination_tx_hash
   destination_tx_sender
+  destination_tx_recipient
+  message_body
 `;
 
 export const messageDetailsFragment = `
 ${messageStubFragment}
-  message_body
   origin_block_hash
   origin_block_height
   origin_block_id
@@ -41,7 +43,6 @@ ${messageStubFragment}
   origin_tx_max_fee_per_gas
   origin_tx_max_priority_fee_per_gas
   origin_tx_nonce
-  origin_tx_recipient
   destination_block_hash
   destination_block_height
   destination_block_id
@@ -54,7 +55,6 @@ ${messageStubFragment}
   destination_tx_max_fee_per_gas
   destination_tx_max_priority_fee_per_gas
   destination_tx_nonce
-  destination_tx_recipient
   total_gas_amount
   total_payment
   num_payments
@@ -81,15 +81,17 @@ export interface MessageStubEntry {
   origin_tx_id: number; // database id
   origin_tx_hash: string; // binary e.g. \\x123
   origin_tx_sender: string; // binary e.g. \\x123
+  origin_tx_recipient: string; // binary e.g. \\x123
   destination_chain_id: number;
   destination_domain_id: number;
   destination_tx_id: number | null; // database id
   destination_tx_hash: string | null; // binary e.g. \\x123
   destination_tx_sender: string | null; // binary e.g. \\x123
+  destination_tx_recipient: string; // binary e.g. \\x123
+  message_body: string | null; // binary e.g. \\x123
 }
 
 export interface MessageEntry extends MessageStubEntry {
-  message_body: string | null; // binary e.g. \\x123
   origin_block_hash: string; // binary e.g. \\x123
   origin_block_height: number;
   origin_block_id: number; // database id
@@ -102,7 +104,6 @@ export interface MessageEntry extends MessageStubEntry {
   origin_tx_max_fee_per_gas: number;
   origin_tx_max_priority_fee_per_gas: number;
   origin_tx_nonce: number;
-  origin_tx_recipient: string; // binary e.g. \\x123
   destination_block_hash: string | null; // binary e.g. \\x123
   destination_block_height: number | null;
   destination_block_id: number | null; // database id
@@ -115,7 +116,6 @@ export interface MessageEntry extends MessageStubEntry {
   destination_tx_max_fee_per_gas: number | null;
   destination_tx_max_priority_fee_per_gas: number | null;
   destination_tx_nonce: number | null;
-  destination_tx_recipient: string; // binary e.g. \\x123
   total_gas_amount: number;
   total_payment: number;
   num_payments: number;

--- a/src/features/messages/utils.ts
+++ b/src/features/messages/utils.ts
@@ -1,6 +1,15 @@
-import { fromBase64, toBase64 } from '@hyperlane-xyz/utils';
-
-import { Message, MessageStub } from '../../types';
+import { MultiProvider } from '@hyperlane-xyz/sdk';
+import {
+  bytesToProtocolAddress,
+  fromBase64,
+  fromHexString,
+  fromWei,
+  parseWarpRouteMessage,
+  toBase64,
+} from '@hyperlane-xyz/utils';
+import { Message, MessageStub, WarpRouteChainAddressMap, WarpRouteDetails } from '../../types';
+import { logger } from '../../utils/logger';
+import { getTokenFromWarpRouteChainAddressMap } from '../../utils/token';
 
 export function serializeMessage(msg: MessageStub | Message): string | undefined {
   return toBase64(msg);
@@ -8,4 +17,63 @@ export function serializeMessage(msg: MessageStub | Message): string | undefined
 
 export function deserializeMessage<M extends MessageStub>(data: string | string[]): M | undefined {
   return fromBase64<M>(data);
+}
+
+export function parseWarpRouteMessageDetails(
+  message: Message | MessageStub,
+  warpRouteChainAddressMap: WarpRouteChainAddressMap,
+  multiProvider: MultiProvider,
+): WarpRouteDetails | undefined {
+  try {
+    const {
+      body,
+      origin: { to },
+      originDomainId,
+      destinationDomainId,
+      recipient,
+    } = message;
+
+    const originMetadata = multiProvider.tryGetChainMetadata(originDomainId);
+    const destinationMetadata = multiProvider.tryGetChainMetadata(destinationDomainId);
+
+    if (!body || !originMetadata || !destinationMetadata) return undefined;
+
+    const originToken = getTokenFromWarpRouteChainAddressMap(
+      originMetadata,
+      to,
+      warpRouteChainAddressMap,
+    );
+    const destinationToken = getTokenFromWarpRouteChainAddressMap(
+      destinationMetadata,
+      recipient,
+      warpRouteChainAddressMap,
+    );
+
+    // If tokens are not found with the addresses, it means the message
+    // is not a warp transfer between tokens known to the registry
+    if (!originToken || !destinationToken) return undefined;
+
+    const parsedMessage = parseWarpRouteMessage(body);
+    const bytes = fromHexString(parsedMessage.recipient);
+    const address = bytesToProtocolAddress(
+      bytes,
+      destinationMetadata.protocol,
+      destinationMetadata.bech32Prefix,
+    );
+
+    return {
+      amount: fromWei(
+        parsedMessage.amount.toString(),
+        Math.max(originToken.decimals, destinationToken.decimals) || 18,
+      ),
+      transferRecipient: address,
+      originTokenAddress: to,
+      originTokenSymbol: originToken.symbol,
+      destinationTokenAddress: recipient,
+      destinationTokenSymbol: destinationToken.symbol,
+    };
+  } catch (err) {
+    logger.error(`Error parsing warp route details for ${message.id}:`, err);
+    return undefined;
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,10 +13,10 @@ export interface MessageTxStub {
   timestamp: number;
   hash: string;
   from: Address;
+  to: Address;
 }
 
 export interface MessageTx extends MessageTxStub {
-  to: Address;
   blockHash: string;
   blockNumber: number;
   mailbox: Address;
@@ -44,10 +44,10 @@ export interface MessageStub {
   origin: MessageTxStub;
   destination?: MessageTxStub;
   isPiMsg?: boolean;
+  body: string;
 }
 
 export interface Message extends MessageStub {
-  body: string;
   decodedBody?: string;
   origin: MessageTx;
   destination?: MessageTx;


### PR DESCRIPTION
fixes #199 

- Now shows warped token in the table row if it is a hyperlane warp route transfer
- Re-use `parseWarpRouteMessageDetails` for this and move to `utils`
- Move the `message_body`, `origin_tx_recipient` and `destination_tx_recipient` from `Message` to `MessageStub`, also match the parsing and typing for this

![image](https://github.com/user-attachments/assets/430238a3-ee7e-4220-8e0a-354ca9be6143)
![image](https://github.com/user-attachments/assets/55527dd3-9957-453a-9e93-854038e46c85)
