### PR TITLE
chore: refactor message parsing and bump registry version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "J M Rossy",
   "dependencies": {
     "@headlessui/react": "^2.2.0",
-    "@hyperlane-xyz/registry": "13.11.0",
+    "@hyperlane-xyz/registry": "15.0.0",
     "@hyperlane-xyz/sdk": "12.3.0",
     "@hyperlane-xyz/utils": "12.3.0",
     "@hyperlane-xyz/widgets": "12.3.0",

--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -119,7 +119,7 @@ export function MessageSummaryRow({
         tdClasses="hidden sm:table-cell"
       >
         {warpRouteDetails ? (
-          warpRouteDetails.originTokenSymbol
+          warpRouteDetails.originToken.symbol
         ) : (
           <Tooltip
             content="Unable to derive token from transfer. Message might not be a Hyperlane warp route token transfer."

--- a/src/features/messages/cards/WarpTransferDetailsCard.tsx
+++ b/src/features/messages/cards/WarpTransferDetailsCard.tsx
@@ -34,19 +34,19 @@ export function WarpTransferDetailsCard({ message, blur }: Props) {
     const originToken = await tryGetBlockExplorerAddressUrl(
       multiProvider,
       message.originChainId,
-      warpRouteDetails.originTokenAddress,
+      warpRouteDetails.originToken.addressOrDenom,
     );
     const destinationToken = await tryGetBlockExplorerAddressUrl(
       multiProvider,
       message.destinationChainId,
-      warpRouteDetails.destinationTokenAddress,
+      warpRouteDetails.destinationToken.addressOrDenom,
     );
     const transferRecipient = await tryGetBlockExplorerAddressUrl(
       multiProvider,
       message.destinationChainId,
       warpRouteDetails.transferRecipient,
     );
-    return { destinationToken, originToken, transferRecipient };
+    return { originToken, destinationToken, transferRecipient };
   }, [message, multiProvider, warpRouteDetails]);
 
   useEffect(() => {
@@ -57,13 +57,7 @@ export function WarpTransferDetailsCard({ message, blur }: Props) {
 
   if (!warpRouteDetails) return null;
 
-  const {
-    amount,
-    destinationTokenAddress,
-    transferRecipient,
-    originTokenAddress,
-    originTokenSymbol,
-  } = warpRouteDetails;
+  const { amount, transferRecipient, originToken, destinationToken } = warpRouteDetails;
 
   return (
     <Card className="w-full space-y-4">
@@ -81,7 +75,7 @@ export function WarpTransferDetailsCard({ message, blur }: Props) {
         <KeyValueRow
           label="Amount:"
           labelWidth="w-20 sm:w-32"
-          display={`${amount} ${originTokenSymbol}`}
+          display={`${amount} ${originToken.symbol}`}
           displayWidth="w-64 sm:w-96"
           blurValue={blur}
           showCopy
@@ -89,7 +83,7 @@ export function WarpTransferDetailsCard({ message, blur }: Props) {
         <KeyValueRow
           label="Origin token:"
           labelWidth="w-20 sm:w-32"
-          display={originTokenAddress}
+          display={originToken.addressOrDenom}
           displayWidth="w-64 sm:w-96"
           blurValue={blur}
           link={blockExplorerAddressUrls?.originToken}
@@ -98,7 +92,7 @@ export function WarpTransferDetailsCard({ message, blur }: Props) {
         <KeyValueRow
           label="Destination token:"
           labelWidth="w-20 sm:w-32"
-          display={destinationTokenAddress}
+          display={destinationToken.addressOrDenom}
           displayWidth="w-64 sm:w-96"
           blurValue={blur}
           link={blockExplorerAddressUrls?.destinationToken}

--- a/src/features/messages/utils.ts
+++ b/src/features/messages/utils.ts
@@ -67,10 +67,8 @@ export function parseWarpRouteMessageDetails(
         Math.max(originToken.decimals, destinationToken.decimals) || 18,
       ),
       transferRecipient: address,
-      originTokenAddress: to,
-      originTokenSymbol: originToken.symbol,
-      destinationTokenAddress: recipient,
-      destinationTokenSymbol: destinationToken.symbol,
+      originToken: originToken,
+      destinationToken: destinationToken,
     };
   } catch (err) {
     logger.error(`Error parsing warp route details for ${message.id}:`, err);

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,10 +65,8 @@ export interface ExtendedLog extends providers.Log {
 export interface WarpRouteDetails {
   amount: string;
   transferRecipient: string;
-  originTokenAddress: string;
-  originTokenSymbol: string;
-  destinationTokenAddress: string;
-  destinationTokenSymbol: string;
+  originToken: TokenArgs;
+  destinationToken: TokenArgs;
 }
 
 export type WarpRouteChainAddressMap = ChainMap<Record<Address, TokenArgs>>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2978,7 +2978,7 @@ __metadata:
   resolution: "@hyperlane-xyz/explorer@workspace:."
   dependencies:
     "@headlessui/react": "npm:^2.2.0"
-    "@hyperlane-xyz/registry": "npm:13.11.0"
+    "@hyperlane-xyz/registry": "npm:15.0.0"
     "@hyperlane-xyz/sdk": "npm:12.3.0"
     "@hyperlane-xyz/utils": "npm:12.3.0"
     "@hyperlane-xyz/widgets": "npm:12.3.0"
@@ -3021,13 +3021,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/registry@npm:13.11.0":
-  version: 13.11.0
-  resolution: "@hyperlane-xyz/registry@npm:13.11.0"
+"@hyperlane-xyz/registry@npm:15.0.0":
+  version: 15.0.0
+  resolution: "@hyperlane-xyz/registry@npm:15.0.0"
   dependencies:
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/d5793a9d60e28058c2064df3bc3dd1c30c44cfc7eee378833c224b2cb20ea1f7a28eadb6a8ce73fcf823f8c8e2d72905e3e12d3d13924722f6319b7ec92baf1f
+  checksum: 10/41cc4635697447ae16a65fe2b5553054a205f37a17d81892d0767f049abbc8abce6ff5cd744a9ea2df32c816a22cab19ec469307c4b62550d91c5cba33f955e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Instead of having one variable for each needed value, refactor the parsing tokens into `originToken` and `destinationToken`, this will also be useful in a future PR to include token icons for the message table
- Upgrade registry verrsion