### PR TITLE
feat: add token logo to message table

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,11 @@ const { version } = require('./package.json');
 
 const isDev = process.env.NODE_ENV !== 'production';
 
+const IMG_SRC_HOSTS = [
+  'https://raw.githubusercontent.com',
+  'https://cdn.jsdelivr.net/gh/hyperlane-xyz/hyperlane-registry@main/',
+];
+
 const securityHeaders = [
   {
     key: 'X-XSS-Protection',
@@ -25,7 +30,7 @@ const securityHeaders = [
     key: 'Content-Security-Policy',
     value: `default-src 'self'; script-src 'self'${
       isDev ? " 'unsafe-eval'" : ''
-    }; connect-src *; img-src 'self' data: https://raw.githubusercontent.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; base-uri 'self'; form-action 'self'`,
+    }; connect-src *; img-src 'self' data: ${IMG_SRC_HOSTS.join(' ')}; style-src 'self' 'unsafe-inline'; font-src 'self' data:; base-uri 'self'; form-action 'self'`,
   },
 ];
 
@@ -51,8 +56,8 @@ const nextConfig = {
       '@hyperlane-xyz/sdk',
       '@hyperlane-xyz/utils',
       '@hyperlane-xyz/widgets',
-    ]
-  }
+    ],
+  },
 };
 
 module.exports = nextConfig;

--- a/src/components/icons/TokenIcon.tsx
+++ b/src/components/icons/TokenIcon.tsx
@@ -1,0 +1,48 @@
+import { TokenArgs } from '@hyperlane-xyz/sdk';
+import { isHttpsUrl, isRelativeUrl } from '@hyperlane-xyz/utils';
+import { Circle } from '@hyperlane-xyz/widgets';
+import { useState } from 'react';
+import { links } from '../../consts/links';
+
+interface Props {
+  token?: TokenArgs | null;
+  size?: number;
+}
+
+export function TokenIcon({ token, size = 32 }: Props) {
+  const title = token?.symbol || '';
+  const character = title ? title.charAt(0).toUpperCase() : '';
+  const fontSize = Math.floor(size / 2);
+
+  const [fallbackToText, setFallbackToText] = useState(false);
+  const imageSrc = getImageSrc(token);
+  const bgColorSeed =
+    token && (!imageSrc || fallbackToText)
+      ? (Buffer.from(token.addressOrDenom).at(0) || 0) % 5
+      : undefined;
+
+  return (
+    <Circle size={size} bgColorSeed={bgColorSeed} title={title}>
+      {imageSrc && !fallbackToText ? (
+        <img
+          src={imageSrc}
+          width={size}
+          height={size}
+          onError={() => setFallbackToText(true)}
+          loading="lazy"
+        />
+      ) : (
+        <div className={`text-[${fontSize}px]`}>{character}</div>
+      )}
+    </Circle>
+  );
+}
+
+function getImageSrc(token?: TokenArgs | null) {
+  if (!token?.logoURI) return null;
+  // If it's a valid, direct URL, return it
+  if (isHttpsUrl(token.logoURI)) return token.logoURI;
+  // Otherwise assume it's a relative URL to the registry base
+  if (isRelativeUrl(token.logoURI)) return `${links.imgPath}${token.logoURI}`;
+  return null;
+}

--- a/src/consts/links.ts
+++ b/src/consts/links.ts
@@ -10,6 +10,7 @@ export const links = {
     'https://docs.tenderly.co/simulations-and-forks/how-to-simulate-a-transaction/using-simulation-ui',
   brand:
     'https://www.figma.com/file/jC5NORmNDCl6WZgjIRwKX5/Hyperlane-Brand-Assets-%5BExternal%5D?type=design&node-id=0-1&t=6eez9F8gttV7L6VG-0',
+  imgPath: 'https://cdn.jsdelivr.net/gh/hyperlane-xyz/hyperlane-registry@main',
 };
 
 export const docLinks = {

--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { PropsWithChildren, useMemo } from 'react';
 import { ChainLogo } from '../../components/icons/ChainLogo';
+import { TokenIcon } from '../../components/icons/TokenIcon';
 import CheckmarkIcon from '../../images/icons/checkmark-circle.svg';
 import ErrorIcon from '../../images/icons/error-circle.svg';
 import { useMultiProvider, useStore } from '../../store';
@@ -92,7 +93,7 @@ export function MessageSummaryRow({
         <ChainLogo chainName={originChainName} size={20} />
         <div className={styles.chainName}>{getChainDisplayName(mp, originChainName, true)}</div>
       </LinkCell>
-      <LinkCell id={msgId} base64={base64} aClasses="flex items-center py-3.5 ">
+      <LinkCell id={msgId} base64={base64} aClasses="flex items-center py-3.5">
         <ChainLogo chainName={destinationChainName} size={20} />
         <div className={styles.chainName}>
           {getChainDisplayName(mp, destinationChainName, true)}
@@ -116,10 +117,13 @@ export function MessageSummaryRow({
         id={msgId}
         base64={base64}
         aClasses={styles.valueTruncated}
-        tdClasses="hidden sm:table-cell"
+        tdClasses="hidden sm:table-cell flex items-center"
       >
         {warpRouteDetails ? (
-          warpRouteDetails.originToken.symbol
+          <>
+            <TokenIcon token={warpRouteDetails.originToken} size={20} />
+            <div className={styles.chainName}>{warpRouteDetails.originToken.symbol}</div>
+          </>
         ) : (
           <Tooltip
             content="Unable to derive token from transfer. Message might not be a Hyperlane warp route token transfer."

--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -91,13 +91,11 @@ export function MessageSummaryRow({
     <>
       <LinkCell id={msgId} base64={base64} aClasses="flex items-center py-3.5 pl-3 sm:pl-5">
         <ChainLogo chainName={originChainName} size={20} />
-        <div className={styles.chainName}>{getChainDisplayName(mp, originChainName, true)}</div>
+        <div className={styles.iconText}>{getChainDisplayName(mp, originChainName, true)}</div>
       </LinkCell>
       <LinkCell id={msgId} base64={base64} aClasses="flex items-center py-3.5">
         <ChainLogo chainName={destinationChainName} size={20} />
-        <div className={styles.chainName}>
-          {getChainDisplayName(mp, destinationChainName, true)}
-        </div>
+        <div className={styles.iconText}>{getChainDisplayName(mp, destinationChainName, true)}</div>
       </LinkCell>
       <LinkCell id={msgId} base64={base64} tdClasses="hidden sm:table-cell" aClasses={styles.value}>
         {shortenAddress(sender) || 'Invalid Address'}
@@ -122,7 +120,7 @@ export function MessageSummaryRow({
         {warpRouteDetails ? (
           <>
             <TokenIcon token={warpRouteDetails.originToken} size={20} />
-            <div className={styles.chainName}>{warpRouteDetails.originToken.symbol}</div>
+            <div className={styles.iconText}>{warpRouteDetails.originToken.symbol}</div>
           </>
         ) : (
           <Tooltip
@@ -175,5 +173,5 @@ const styles = {
   header: 'text-sm text-blue-500 font-medium pt-2 pb-3 text-center',
   value: 'py-3.5 flex items-center justify-center text-sm text-center font-light px-1',
   valueTruncated: 'py-3.5 flex items-center justify-center text-sm text-center font-light truncate',
-  chainName: 'text-sm font-light ml-2',
+  iconText: 'text-sm font-light ml-2',
 };

--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -114,8 +114,8 @@ export function MessageSummaryRow({
       <LinkCell
         id={msgId}
         base64={base64}
-        aClasses={styles.valueTruncated}
-        tdClasses="hidden sm:table-cell flex items-center"
+        aClasses="flex items-center justify-center py-3.5"
+        tdClasses="hidden sm:table-cell"
       >
         {warpRouteDetails ? (
           <>


### PR DESCRIPTION
- Update MessageTable and the warped token field to include a logo
- Add `TokenIcon` component
- Use the public CDN jsdelivr to get these images
- Update img-src permission to include jsdelivr image from the registry
![Screenshot 2025-05-12 at 4 32 22 PM](https://github.com/user-attachments/assets/7d49b7be-286c-4dcf-a26d-a818adf90521)
