### PR TITLE
chore: improve styling for warped route token

### DIFF
--- a/src/components/icons/TokenIcon.tsx
+++ b/src/components/icons/TokenIcon.tsx
@@ -26,8 +26,7 @@ export function TokenIcon({ token, size = 32 }: Props) {
       {imageSrc && !fallbackToText ? (
         <img
           src={imageSrc}
-          width={size}
-          height={size}
+          className="h-full w-full"
           onError={() => setFallbackToText(true)}
           loading="lazy"
         />

--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -114,7 +114,7 @@ export function MessageSummaryRow({
       <LinkCell
         id={msgId}
         base64={base64}
-        aClasses="flex items-center justify-center py-3.5"
+        aClasses={`flex items-center py-3.5 ${warpRouteDetails ? 'ml-4' : 'justify-center'}`}
         tdClasses="hidden sm:table-cell"
       >
         {warpRouteDetails ? (

--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -1,6 +1,5 @@
 import { MultiProvider } from '@hyperlane-xyz/sdk';
 import { shortenAddress } from '@hyperlane-xyz/utils';
-import { Tooltip } from '@hyperlane-xyz/widgets';
 import Image from 'next/image';
 import Link from 'next/link';
 import { PropsWithChildren, useMemo } from 'react';
@@ -33,8 +32,8 @@ export function MessageTable({
           <th className={`${styles.header} hidden sm:table-cell`}>Sender</th>
           <th className={`${styles.header} hidden sm:table-cell`}>Recipient</th>
           <th className={`${styles.header} hidden lg:table-cell`}>Origin Tx</th>
-          <th className={`${styles.header} hidden sm:table-cell`}>Warped Token</th>
           <th className={styles.header}>Time sent</th>
+          <th className={`${styles.header} hidden sm:table-cell`}>Warped Token</th>
         </tr>
       </thead>
       <tbody>
@@ -111,6 +110,9 @@ export function MessageSummaryRow({
       >
         {shortenAddress(origin.hash)}
       </LinkCell>
+      <LinkCell id={msgId} base64={base64} aClasses={styles.valueTruncated}>
+        {getHumanReadableTimeString(origin.timestamp)}
+      </LinkCell>
       <LinkCell
         id={msgId}
         base64={base64}
@@ -122,16 +124,7 @@ export function MessageSummaryRow({
             <TokenIcon token={warpRouteDetails.originToken} size={20} />
             <div className={styles.iconText}>{warpRouteDetails.originToken.symbol}</div>
           </>
-        ) : (
-          <Tooltip
-            content="Unable to derive token from transfer. Message might not be a Hyperlane warp route token transfer."
-            id="no-token-info"
-            tooltipClassName="whitespace-normal break-words text-left"
-          />
-        )}
-      </LinkCell>
-      <LinkCell id={msgId} base64={base64} aClasses={styles.valueTruncated}>
-        {getHumanReadableTimeString(origin.timestamp)}
+        ) : null}
       </LinkCell>
       <LinkCell id={msgId} base64={base64} tdClasses="w-8">
         {statusIcon && (

--- a/src/features/messages/cards/WarpTransferDetailsCard.tsx
+++ b/src/features/messages/cards/WarpTransferDetailsCard.tsx
@@ -1,7 +1,9 @@
 import { Tooltip } from '@hyperlane-xyz/widgets';
+import Image from 'next/image';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { TokenIcon } from '../../../components/icons/TokenIcon';
 import { Card } from '../../../components/layout/Card';
+import SendMoney from '../../../images/icons/send-money.svg';
 import { useMultiProvider, useStore } from '../../../store';
 import { Message } from '../../../types';
 import { tryGetBlockExplorerAddressUrl } from '../../../utils/url';
@@ -61,7 +63,11 @@ export function WarpTransferDetailsCard({ message, blur }: Props) {
   return (
     <Card className="w-full space-y-4">
       <div className="flex items-center justify-between">
-        <TokenIcon token={warpRouteDetails.originToken} size={28} />
+        {warpRouteDetails.originToken.logoURI ? (
+          <TokenIcon token={warpRouteDetails.originToken} size={28} />
+        ) : (
+          <Image src={SendMoney} width={28} height={28} alt="" className="opacity-80" />
+        )}
         <div className="flex items-center pb-1">
           <h3 className="mr-2 text-md font-medium text-blue-500">Warp Transfer Details</h3>
           <Tooltip

--- a/src/features/messages/cards/WarpTransferDetailsCard.tsx
+++ b/src/features/messages/cards/WarpTransferDetailsCard.tsx
@@ -1,8 +1,7 @@
 import { Tooltip } from '@hyperlane-xyz/widgets';
-import Image from 'next/image';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { TokenIcon } from '../../../components/icons/TokenIcon';
 import { Card } from '../../../components/layout/Card';
-import SendMoney from '../../../images/icons/send-money.svg';
 import { useMultiProvider, useStore } from '../../../store';
 import { Message } from '../../../types';
 import { tryGetBlockExplorerAddressUrl } from '../../../utils/url';
@@ -62,7 +61,7 @@ export function WarpTransferDetailsCard({ message, blur }: Props) {
   return (
     <Card className="w-full space-y-4">
       <div className="flex items-center justify-between">
-        <Image src={SendMoney} width={28} height={28} alt="" className="opacity-80" />
+        <TokenIcon token={warpRouteDetails.originToken} size={28} />
         <div className="flex items-center pb-1">
           <h3 className="mr-2 text-md font-medium text-blue-500">Warp Transfer Details</h3>
           <Tooltip


### PR DESCRIPTION
- Fix img size issue for token icon
- Improve warped token row positioning
- Remove tooltip for token row and use empty space instead
- Now will show token icon for Warp Transfer Detail image if logoURI it exists
![Screenshot 2025-05-13 at 10 17 48 AM](https://github.com/user-attachments/assets/8f824154-90df-491d-b003-35cada0005ac)
![image](https://github.com/user-attachments/assets/e8bba9f2-ecf8-4e3a-8973-8cee75d12775)
![Screenshot 2025-05-13 at 10 17 54 AM](https://github.com/user-attachments/assets/a0b871af-29cf-41de-82ca-7dbd18505662)
