### PR TITLE
fix: search query where clause

### DIFF
--- a/src/features/messages/queries/build.ts
+++ b/src/features/messages/queries/build.ts
@@ -144,12 +144,10 @@ function buildSearchWhereClauses(searchInput: string) {
     );
   }
   if (isPotentiallyTransactionHash(searchInput)) {
-    clauses.push(
-      `{msg_id: {_eq: $search}}`,
-      `{origin_tx_hash: {_eq: $search}}`,
-      `{destination_tx_hash: {_eq: $search}}`,
-    );
+    clauses.push(`{origin_tx_hash: {_eq: $search}}`, `{destination_tx_hash: {_eq: $search}}`);
   }
+  clauses.push(`{msg_id: {_eq: $search}}`);
+
   return clauses;
 }
 


### PR DESCRIPTION
Fixed an issue where query would be empty if it was not a transaction hash, now it will always include the `msg_id` even if it is not an `address` or tx hash