### PR TITLE
feat: use GithubRegistry to get warp routes data

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "J M Rossy",
   "dependencies": {
     "@headlessui/react": "^2.2.0",
-    "@hyperlane-xyz/registry": "17.1.0",
+    "@hyperlane-xyz/registry": "17.4.0",
     "@hyperlane-xyz/sdk": "13.2.1",
     "@hyperlane-xyz/utils": "13.2.1",
     "@hyperlane-xyz/widgets": "13.2.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "J M Rossy",
   "dependencies": {
     "@headlessui/react": "^2.2.0",
-    "@hyperlane-xyz/registry": "16.1.0",
+    "@hyperlane-xyz/registry": "17.1.0",
     "@hyperlane-xyz/sdk": "13.2.1",
     "@hyperlane-xyz/utils": "13.2.1",
     "@hyperlane-xyz/widgets": "13.2.1",

--- a/src/components/icons/ChainLogo.tsx
+++ b/src/components/icons/ChainLogo.tsx
@@ -1,6 +1,8 @@
 import { ChainLogo as ChainLogoInner } from '@hyperlane-xyz/widgets';
 
-import { useRegistry } from '../../store';
+import Image from 'next/image';
+import { useMemo } from 'react';
+import { useChainMetadata, useRegistry } from '../../store';
 
 export function ChainLogo({
   chainName,
@@ -12,8 +14,28 @@ export function ChainLogo({
   size?: number;
 }) {
   const registry = useRegistry();
-  const name = chainName || '';
+  const chainMetadata = useChainMetadata(chainName);
+  const { name, Icon } = useMemo(() => {
+    const name = chainMetadata?.name || '';
+    const logoUri = chainMetadata?.logoURI;
+    const Icon = logoUri
+      ? (props: { width: number; height: number; title?: string }) => (
+          <Image src={logoUri} alt="" {...props} />
+        )
+      : undefined;
+    return {
+      name,
+      Icon,
+    };
+  }, [chainMetadata]);
+
   return (
-    <ChainLogoInner chainName={name} registry={registry} size={size} background={background} />
+    <ChainLogoInner
+      chainName={name}
+      registry={registry}
+      size={size}
+      background={background}
+      Icon={Icon}
+    />
   );
 }

--- a/src/consts/config.ts
+++ b/src/consts/config.ts
@@ -1,5 +1,7 @@
 const isDevMode = process?.env?.NODE_ENV === 'development';
 const version = process?.env?.NEXT_PUBLIC_VERSION ?? null;
+const registryUrl = process?.env?.NEXT_PUBLIC_REGISTRY_URL || undefined;
+const registryBranch = process?.env?.NEXT_PUBLIC_REGISTRY_BRANCH || 'main';
 const explorerApiKeys = JSON.parse(process?.env?.EXPLORER_API_KEYS || '{}');
 
 interface Config {
@@ -8,6 +10,8 @@ interface Config {
   apiUrl: string;
   explorerApiKeys: Record<string, string>;
   githubProxy?: string;
+  registryUrl: string | undefined; // Optional URL to use a custom registry instead of the published canonical version
+  registryBranch?: string | undefined; // Optional customization of the registry branch instead of main
 }
 
 export const config: Config = Object.freeze({
@@ -16,6 +20,8 @@ export const config: Config = Object.freeze({
   apiUrl: 'https://explorer4.hasura.app/v1/graphql',
   explorerApiKeys,
   githubProxy: 'https://proxy.hyperlane.xyz',
+  registryBranch,
+  registryUrl,
 });
 
 // Based on https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/infra/config/environments/mainnet3/agent.ts

--- a/yarn.lock
+++ b/yarn.lock
@@ -2978,7 +2978,7 @@ __metadata:
   resolution: "@hyperlane-xyz/explorer@workspace:."
   dependencies:
     "@headlessui/react": "npm:^2.2.0"
-    "@hyperlane-xyz/registry": "npm:16.1.0"
+    "@hyperlane-xyz/registry": "npm:17.1.0"
     "@hyperlane-xyz/sdk": "npm:13.2.1"
     "@hyperlane-xyz/utils": "npm:13.2.1"
     "@hyperlane-xyz/widgets": "npm:13.2.1"
@@ -3021,14 +3021,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/registry@npm:16.1.0":
-  version: 16.1.0
-  resolution: "@hyperlane-xyz/registry@npm:16.1.0"
+"@hyperlane-xyz/registry@npm:17.1.0":
+  version: 17.1.0
+  resolution: "@hyperlane-xyz/registry@npm:17.1.0"
   dependencies:
     jszip: "npm:^3.10.1"
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/706a1fad274633807a45a1b16a5ca4fad78e1c9826ccfebff4f2b081f190f0959d18d00d85de52898e7db599c79c66b399e0a1b3650b2fd4725ccb0bc46cc98e
+  checksum: 10/2bff999de1a8d6ebb54fca1d4f5f3bceb26af9d9abe0b8ff129bc387dd744bd0dbe68a70755830f14369c3aed29fe1edd932d86c311d0764ebd48d3e105f88ee
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2978,7 +2978,7 @@ __metadata:
   resolution: "@hyperlane-xyz/explorer@workspace:."
   dependencies:
     "@headlessui/react": "npm:^2.2.0"
-    "@hyperlane-xyz/registry": "npm:17.1.0"
+    "@hyperlane-xyz/registry": "npm:17.4.0"
     "@hyperlane-xyz/sdk": "npm:13.2.1"
     "@hyperlane-xyz/utils": "npm:13.2.1"
     "@hyperlane-xyz/widgets": "npm:13.2.1"
@@ -3021,14 +3021,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/registry@npm:17.1.0":
-  version: 17.1.0
-  resolution: "@hyperlane-xyz/registry@npm:17.1.0"
+"@hyperlane-xyz/registry@npm:17.4.0":
+  version: 17.4.0
+  resolution: "@hyperlane-xyz/registry@npm:17.4.0"
   dependencies:
     jszip: "npm:^3.10.1"
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/2bff999de1a8d6ebb54fca1d4f5f3bceb26af9d9abe0b8ff129bc387dd744bd0dbe68a70755830f14369c3aed29fe1edd932d86c311d0764ebd48d3e105f88ee
+  checksum: 10/4899eb332087c814e61d46d2b502aaff01251f85254a92ba26c7be412d12c52f4824238cec2a2a8ce55f4a74a0041c505b75a21a9720ae9ee49a7453b73a7af1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR switches the build `warpRouteChainAddressMap` is built by using `GithubRegistry` to fetch most up to date warp routes instead of using published warp routes

- Now calls `getWarpRoutes()` from `GithubRegistry` to build warpRouteChainAddressMap, fall backs to published warp routes if it fails
- Change Chain logos to fetch from `CDN` instead of `github` direct link
- Bump registry version

fixes [ENG-1741](https://linear.app/hyperlane-xyz/issue/ENG-1741/use-githubregistry-for-explorer)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for custom registry URL and branch through new environment variables.
  - Introduced a utility to retrieve chain metadata by chain name.
  - Enhanced chain logo component to display logos and names based on metadata.

- **Improvements**
  - Improved registry initialization and configuration flexibility.
  - Enhanced management and retrieval of warp route chain address maps, with fallback to published configs if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->