### PR TITLE
feat: format addresses and tx hashes

### DIFF
--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -9,6 +9,7 @@ import CheckmarkIcon from '../../images/icons/checkmark-circle.svg';
 import ErrorIcon from '../../images/icons/error-circle.svg';
 import { useMultiProvider, useStore } from '../../store';
 import { MessageStatus, MessageStub, WarpRouteChainAddressMap } from '../../types';
+import { formatAddress, formatTxHash } from '../../utils/addresses';
 import { getHumanReadableTimeString } from '../../utils/time';
 import { getChainDisplayName } from '../chains/utils';
 import { parseWarpRouteMessageDetails, serializeMessage } from './utils';
@@ -67,6 +68,10 @@ export function MessageSummaryRow({
 }) {
   const { msgId, status, sender, recipient, originDomainId, destinationDomainId, origin } = message;
 
+  const formattedSender = formatAddress(sender, originDomainId, mp);
+  const formattedRecipient = formatAddress(recipient, destinationDomainId, mp);
+  const formattedTxHash = formatTxHash(origin.hash, originDomainId, mp);
+
   let statusIcon = undefined;
   let statusTitle = '';
   if (status === MessageStatus.Delivered) {
@@ -97,10 +102,10 @@ export function MessageSummaryRow({
         <div className={styles.iconText}>{getChainDisplayName(mp, destinationChainName, true)}</div>
       </LinkCell>
       <LinkCell id={msgId} base64={base64} tdClasses="hidden sm:table-cell" aClasses={styles.value}>
-        {shortenAddress(sender) || 'Invalid Address'}
+        {shortenAddress(formattedSender) || 'Invalid Address'}
       </LinkCell>
       <LinkCell id={msgId} base64={base64} tdClasses="hidden sm:table-cell" aClasses={styles.value}>
-        {shortenAddress(recipient) || 'Invalid Address'}
+        {shortenAddress(formattedRecipient) || 'Invalid Address'}
       </LinkCell>
       <LinkCell
         id={msgId}
@@ -108,7 +113,7 @@ export function MessageSummaryRow({
         tdClasses="hidden lg:table-cell"
         aClasses={styles.valueTruncated}
       >
-        {shortenAddress(origin.hash)}
+        {shortenAddress(formattedTxHash)}
       </LinkCell>
       <LinkCell id={msgId} base64={base64} aClasses={styles.valueTruncated}>
         {getHumanReadableTimeString(origin.timestamp)}

--- a/src/features/messages/cards/ContentDetailsCard.tsx
+++ b/src/features/messages/cards/ContentDetailsCard.tsx
@@ -1,5 +1,5 @@
-import { MAILBOX_VERSION, MultiProvider } from '@hyperlane-xyz/sdk';
-import { formatMessage, hexToRadixCustomPrefix, ProtocolType } from '@hyperlane-xyz/utils';
+import { MAILBOX_VERSION } from '@hyperlane-xyz/sdk';
+import { formatMessage } from '@hyperlane-xyz/utils';
 import { SelectField, Tooltip } from '@hyperlane-xyz/widgets';
 import Image from 'next/image';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -7,6 +7,7 @@ import { Card } from '../../../components/layout/Card';
 import EnvelopeInfo from '../../../images/icons/envelope-info.svg';
 import { useMultiProvider } from '../../../store';
 import { Message } from '../../../types';
+import { formatAddress } from '../../../utils/addresses';
 import { logger } from '../../../utils/logger';
 import { tryUtf8DecodeBytes } from '../../../utils/string';
 import { tryGetBlockExplorerAddressUrl } from '../../../utils/url';
@@ -18,13 +19,6 @@ interface Props {
   message: Message;
   blur: boolean;
 }
-
-const formatSenderOrRecipient = (address: string, domain: number, multiProvider: MultiProvider) => {
-  const metadata = multiProvider.tryGetChainMetadata(domain);
-  if (metadata?.protocol === ProtocolType.Radix)
-    return hexToRadixCustomPrefix(address, 'component', metadata?.bech32Prefix, 30);
-  return address;
-};
 
 export function ContentDetailsCard({
   message: {
@@ -47,8 +41,8 @@ export function ContentDetailsCard({
     BlockExplorerAddressUrls | undefined
   >(undefined);
 
-  const formattedRecipient = formatSenderOrRecipient(recipient, destinationDomainId, multiProvider);
-  const formattedSender = formatSenderOrRecipient(sender, originDomainId, multiProvider);
+  const formattedRecipient = formatAddress(recipient, destinationDomainId, multiProvider);
+  const formattedSender = formatAddress(sender, originDomainId, multiProvider);
 
   useEffect(() => {
     if (decodedBody) setBodyDecodeType('utf8');

--- a/src/features/messages/cards/TransactionCard.tsx
+++ b/src/features/messages/cards/TransactionCard.tsx
@@ -1,11 +1,5 @@
-import { ChainMetadata, MultiProvider } from '@hyperlane-xyz/sdk';
-import {
-  ProtocolType,
-  hexToRadixCustomPrefix,
-  isAddress,
-  isZeroish,
-  strip0x,
-} from '@hyperlane-xyz/utils';
+import { MultiProvider } from '@hyperlane-xyz/sdk';
+import { isAddress, isZeroish } from '@hyperlane-xyz/utils';
 import { Modal, SpinnerIcon, Tooltip, useModal } from '@hyperlane-xyz/widgets';
 import BigNumber from 'bignumber.js';
 import { PropsWithChildren, ReactNode, useState } from 'react';
@@ -14,6 +8,7 @@ import { Card } from '../../../components/layout/Card';
 import { links } from '../../../consts/links';
 import { useMultiProvider } from '../../../store';
 import { MessageStatus, MessageTx } from '../../../types';
+import { formatAddress, formatTxHash } from '../../../utils/addresses';
 import { getDateTimeString, getHumanReadableTimeString } from '../../../utils/time';
 import { ChainSearchModal } from '../../chains/ChainSearchModal';
 import { getChainDisplayName, isEvmChain } from '../../chains/utils';
@@ -193,17 +188,6 @@ function TransactionCard({
   );
 }
 
-function getFormattedTransactionHash(hash: string, metadata: ChainMetadata | null) {
-  switch (metadata?.protocol) {
-    case ProtocolType.Radix:
-      return hexToRadixCustomPrefix(hash, 'txid', metadata?.bech32Prefix);
-    case ProtocolType.Cosmos:
-      return strip0x(hash);
-    default:
-      return hash;
-  }
-}
-
 function TransactionDetails({
   chainName,
   domainId,
@@ -218,17 +202,10 @@ function TransactionDetails({
   blur: boolean;
 }) {
   const multiProvider = useMultiProvider();
-  const protocol = multiProvider.tryGetProtocol(domainId) || ProtocolType.Ethereum;
-  const metadata = multiProvider.tryGetChainMetadata(domainId);
-
   const { hash, from, timestamp, blockNumber, mailbox } = transaction;
 
-  const formattedHash = getFormattedTransactionHash(hash, metadata);
-
-  const formattedMailbox =
-    protocol === ProtocolType.Radix
-      ? hexToRadixCustomPrefix(mailbox, 'component', metadata?.bech32Prefix, 30)
-      : mailbox;
+  const formattedHash = formatTxHash(hash, domainId, multiProvider);
+  const formattedMailbox = formatAddress(mailbox, domainId, multiProvider);
 
   const txExplorerLink =
     hash && !new BigNumber(hash).isZero()

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -1,0 +1,22 @@
+import { MultiProvider } from '@hyperlane-xyz/sdk';
+import { hexToRadixCustomPrefix, ProtocolType, strip0x } from '@hyperlane-xyz/utils';
+
+export function formatAddress(address: string, domainId: number, multiProvider: MultiProvider) {
+  const metadata = multiProvider.tryGetChainMetadata(domainId);
+  if (metadata?.protocol === ProtocolType.Radix)
+    return hexToRadixCustomPrefix(address, 'component', metadata?.bech32Prefix, 30);
+  return address;
+}
+
+export function formatTxHash(hash: string, domainId: number, multiProvider: MultiProvider) {
+  const metadata = multiProvider.tryGetChainMetadata(domainId);
+
+  switch (metadata?.protocol) {
+    case ProtocolType.Radix:
+      return hexToRadixCustomPrefix(hash, 'txid', metadata?.bech32Prefix);
+    case ProtocolType.Cosmos:
+      return strip0x(hash);
+    default:
+      return hash;
+  }
+}


### PR DESCRIPTION
fixes [AW-144](https://linear.app/hyperlane-xyz/issue/AW-144/explorer-sender-and-txhash-for-radix-wrong-in-messagelist)

- Move addresses and tx hash format functions into utils
- Now formats `sender`, `recipient` and `origin.hash` in the Message Table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chain-aware formatting for addresses and transaction hashes across message tables and transaction/detail views for improved readability (e.g., Radix/Cosmos conventions).
  * Explorer links continue to function with the newly formatted values.

* **Bug Fixes**
  * Corrected presentation of hashes/addresses on certain chains (e.g., removing unnecessary prefixes), reducing confusion in the UI.

* **Refactor**
  * Centralized address and transaction hash formatting into shared utilities, replacing scattered protocol-specific logic for consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->