### PR TITLE
feat: parse sender and recipient for warp route message details

### DIFF
--- a/src/features/messages/utils.ts
+++ b/src/features/messages/utils.ts
@@ -8,6 +8,7 @@ import {
   toBase64,
 } from '@hyperlane-xyz/utils';
 import { Message, MessageStub, WarpRouteChainAddressMap, WarpRouteDetails } from '../../types';
+import { formatAddress } from '../../utils/addresses';
 import { logger } from '../../utils/logger';
 import { getTokenFromWarpRouteChainAddressMap } from '../../utils/token';
 
@@ -32,14 +33,17 @@ export function parseWarpRouteMessageDetails(
 
     if (!body || !originMetadata || !destinationMetadata) return undefined;
 
+    const parsedSender = formatAddress(sender, originDomainId, multiProvider);
+    const parsedRecipient = formatAddress(recipient, destinationDomainId, multiProvider);
+
     const originToken = getTokenFromWarpRouteChainAddressMap(
       originMetadata,
-      sender,
+      parsedSender,
       warpRouteChainAddressMap,
     );
     const destinationToken = getTokenFromWarpRouteChainAddressMap(
       destinationMetadata,
-      recipient,
+      parsedRecipient,
       warpRouteChainAddressMap,
     );
 


### PR DESCRIPTION
This PR allows the explorer to format sender/recipient correctly for alt-VMs

before:
<img width="956" height="747" alt="image" src="https://github.com/user-attachments/assets/0892510c-59b7-4a27-867d-f53ba491f76b" />
<img width="930" height="636" alt="image" src="https://github.com/user-attachments/assets/dc0a36b1-6e29-4db9-b3be-f47281caea30" />

after:
<img width="948" height="582" alt="image" src="https://github.com/user-attachments/assets/aac3bda3-990a-4c1d-af11-cb80d3f678d7" />
<img width="934" height="645" alt="image" src="https://github.com/user-attachments/assets/254147f2-2f3f-4878-acc0-031c42cf783a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved accuracy of token identification in message details by using consistently formatted addresses.
  - Prevents mismatched or “unknown” token displays and ensures sender/recipient info is consistent across networks.

- Refactor
  - Streamlined address handling within message parsing to reduce edge-case errors and improve reliability.

- Tests
  - None

- Chores
  - None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->