### PR TITLE
fix: address react doctor findings

### DIFF
--- a/src/components/icons/TokenIcon.tsx
+++ b/src/components/icons/TokenIcon.tsx
@@ -26,6 +26,7 @@ export function TokenIcon({ token, size = 32 }: Props) {
       {imageSrc && !fallbackToText ? (
         <img
           src={imageSrc}
+          alt={title}
           className="h-full w-full"
           onError={() => setFallbackToText(true)}
           loading="lazy"

--- a/src/components/search/SearchFilterBar.tsx
+++ b/src/components/search/SearchFilterBar.tsx
@@ -131,6 +131,16 @@ function DatetimeSelector({
   // Need local state as buffer before user hits apply
   const [startTime, setStartTime] = useState<number | null>(startValue);
   const [endTime, setEndTime] = useState<number | null>(endValue);
+  const [prevStartValue, setPrevStartValue] = useState(startValue);
+  const [prevEndValue, setPrevEndValue] = useState(endValue);
+  if (startValue !== prevStartValue) {
+    setPrevStartValue(startValue);
+    setStartTime(startValue);
+  }
+  if (endValue !== prevEndValue) {
+    setPrevEndValue(endValue);
+    setEndTime(endValue);
+  }
 
   const onClickClear = () => {
     setStartTime(null);

--- a/src/features/messages/MessageSearch.tsx
+++ b/src/features/messages/MessageSearch.tsx
@@ -101,13 +101,13 @@ export function MessageSearch() {
   const [destinationChainFilter, setDestinationChainFilter] = useState<string | null>(
     defaultDestinationQuery || null,
   );
-  const [startTimeFilter, setStartTimeFilter] = useState<number | null>(
+  const [startTimeFilter, setStartTimeFilter] = useState<number | null>(() =>
     tryToDecimalNumber(defaultStartTime),
   );
-  const [endTimeFilter, setEndTimeFilter] = useState<number | null>(
+  const [endTimeFilter, setEndTimeFilter] = useState<number | null>(() =>
     tryToDecimalNumber(defaultEndTime),
   );
-  const [statusFilter, setStatusFilter] = useState<MessageStatusFilter>(
+  const [statusFilter, setStatusFilter] = useState<MessageStatusFilter>(() =>
     parseStatusFilter(defaultStatus),
   );
 

--- a/src/features/messages/cards/CollateralCards.tsx
+++ b/src/features/messages/cards/CollateralCards.tsx
@@ -98,8 +98,8 @@ function RebalanceList({ rebalances }: { rebalances: RebalanceInfo[] }) {
         {count} rebalance transaction{count > 1 ? 's' : ''} in progress:
       </p>
       <ul className="space-y-2">
-        {pendingRebalances.slice(0, 3).map((rebalance, idx) => (
-          <li key={idx} className="flex items-center space-x-2 text-xs">
+        {pendingRebalances.slice(0, 3).map((rebalance) => (
+          <li key={rebalance.txHash} className="flex items-center space-x-2 text-xs">
             <span className="rounded bg-white font-mono">{rebalance.txHash.slice(0, 12)}...</span>
             {rebalance.messageId && (
               <Link

--- a/src/features/messages/cards/ContentDetailsCard.tsx
+++ b/src/features/messages/cards/ContentDetailsCard.tsx
@@ -37,16 +37,17 @@ export function ContentDetailsCard({
 }: Props) {
   const multiProvider = useMultiProvider();
   const [bodyDecodeType, setBodyDecodeType] = useState<string>(decodedBody ? 'utf8' : 'hex');
+  const [prevDecodedBody, setPrevDecodedBody] = useState(decodedBody);
+  if (decodedBody !== prevDecodedBody) {
+    setPrevDecodedBody(decodedBody);
+    if (decodedBody) setBodyDecodeType('utf8');
+  }
   const [blockExplorerAddressUrls, setBlockExplorerAddressUrls] = useState<
     BlockExplorerAddressUrls | undefined
   >(undefined);
 
   const formattedRecipient = formatAddress(recipient, destinationDomainId, multiProvider);
   const formattedSender = formatAddress(sender, originDomainId, multiProvider);
-
-  useEffect(() => {
-    if (decodedBody) setBodyDecodeType('utf8');
-  }, [decodedBody]);
   const onChangeBodyDecode = (value: string) => {
     setBodyDecodeType(value);
   };
@@ -143,7 +144,7 @@ export function ContentDetailsCard({
       </div>
       <div>
         <div className="flex items-center">
-          <label className="text-sm text-gray-500">Message Content:</label>
+          <span className="text-sm text-gray-500">Message Content:</span>
           <SelectField
             classes="w-16 h-7 py-0.5 ml-3 mb-0.5"
             options={decodeOptions}

--- a/src/features/messages/cards/GasDetailsCard.tsx
+++ b/src/features/messages/cards/GasDetailsCard.tsx
@@ -15,13 +15,15 @@ import { GasPayment } from '../../debugger/types';
 
 import { KeyValueRow } from './KeyValueRow';
 
+const EMPTY_IGP_PAYMENTS: AddressTo<GasPayment[]> = {};
+
 interface Props {
   message: Message;
   igpPayments?: AddressTo<GasPayment[]>;
   blur: boolean;
 }
 
-export function GasDetailsCard({ message, blur, igpPayments = {} }: Props) {
+export function GasDetailsCard({ message, blur, igpPayments = EMPTY_IGP_PAYMENTS }: Props) {
   const multiProvider = useMultiProvider();
   const unitOptions = useMemo(() => {
     const originMetadata = multiProvider.tryGetChainMetadata(message.originDomainId);
@@ -157,7 +159,7 @@ function IgpPaymentsTable({ payments }: { payments: Array<GasPayment & { contrac
       </thead>
       <tbody>
         {payments.map((p, i) => (
-          <tr key={`igp-payment-${i}`}>
+          <tr key={`${p.contract}-${p.gasAmount}-${i}`}>
             <td className={style.td}>{p.contract}</td>
             <td className={style.td}>{p.gasAmount}</td>
             <td className={style.td}>{p.paymentAmount}</td>

--- a/src/features/messages/cards/IcaDetailsCard.tsx
+++ b/src/features/messages/cards/IcaDetailsCard.tsx
@@ -64,10 +64,10 @@ export function IcaDetailsCard({ message: { originDomainId, body }, blur }: Prop
           />
           {decodeResult.calls.length ? (
             decodeResult.calls.map((c, i) => (
-              <div key={`ica-call-${i}`}>
-                <label className="text-sm text-gray-500">{`Function call ${i + 1} of ${
+              <div key={`${c.destinationAddress}-${i}`}>
+                <span className="text-sm text-gray-500">{`Function call ${i + 1} of ${
                   decodeResult.calls.length
-                }:`}</label>
+                }:`}</span>
                 <div className="mt-2 space-y-2.5 border-l-2 border-gray-400 pl-4">
                   <KeyValueRow
                     label="Destination address:"
@@ -90,7 +90,7 @@ export function IcaDetailsCard({ message: { originDomainId, body }, blur }: Prop
             ))
           ) : (
             <div>
-              <label className="text-sm text-gray-500">Call List:</label>
+              <span className="text-sm text-gray-500">Call List:</span>
               <div className="mt-1 text-sm italic">No calls found for this message.</div>
             </div>
           )}

--- a/src/features/messages/cards/WarpTransferDetailsCard.tsx
+++ b/src/features/messages/cards/WarpTransferDetailsCard.tsx
@@ -28,21 +28,23 @@ export function WarpTransferDetailsCard({ message, warpRouteDetails, blur }: Pro
   > => {
     if (!warpRouteDetails) return undefined;
 
-    const originToken = await tryGetBlockExplorerAddressUrl(
-      multiProvider,
-      message.originChainId,
-      warpRouteDetails.originToken.addressOrDenom,
-    );
-    const destinationToken = await tryGetBlockExplorerAddressUrl(
-      multiProvider,
-      message.destinationChainId,
-      warpRouteDetails.destinationToken.addressOrDenom,
-    );
-    const transferRecipient = await tryGetBlockExplorerAddressUrl(
-      multiProvider,
-      message.destinationChainId,
-      warpRouteDetails.transferRecipient,
-    );
+    const [originToken, destinationToken, transferRecipient] = await Promise.all([
+      tryGetBlockExplorerAddressUrl(
+        multiProvider,
+        message.originChainId,
+        warpRouteDetails.originToken.addressOrDenom,
+      ),
+      tryGetBlockExplorerAddressUrl(
+        multiProvider,
+        message.destinationChainId,
+        warpRouteDetails.destinationToken.addressOrDenom,
+      ),
+      tryGetBlockExplorerAddressUrl(
+        multiProvider,
+        message.destinationChainId,
+        warpRouteDetails.transferRecipient,
+      ),
+    ]);
     return { originToken, destinationToken, transferRecipient };
   }, [message, multiProvider, warpRouteDetails]);
 

--- a/src/pages/api/og.tsx
+++ b/src/pages/api/og.tsx
@@ -295,6 +295,7 @@ export default async function handler(req: NextRequest) {
         {/* Sparkle background */}
         <img
           src={backgroundUrl}
+          alt=""
           style={{
             position: 'absolute',
             top: '-75%',


### PR DESCRIPTION
## Summary

Addresses React Doctor findings from #279. Minimal changes only.

**Errors fixed:**
- `TokenIcon.tsx`: add missing `alt={title}` on `<img>`
- `og.tsx`: add missing `alt=""` on background `<img>`

**Warnings fixed:**
- `ContentDetailsCard.tsx`: replace `useEffect` with render-time state sync for `bodyDecodeType`; change unassociated `<label>` to `<span>`
- `SearchFilterBar.tsx`: sync local `DatetimeSelector` state when props change externally
- `CollateralCards.tsx`: use `txHash` as stable React key instead of array index
- `IcaDetailsCard.tsx`: use `destinationAddress` in key; change `<label>` to `<span>`
- `GasDetailsCard.tsx`: extract default `{}` to module-level constant; use composite key
- `WarpTransferDetailsCard.tsx`: parallelize 3 independent `await`s with `Promise.all()`
- `MessageSearch.tsx`: wrap `useState` initializers calling `tryToDecimalNumber()` / `parseStatusFilter()` in lazy arrow functions

**Intentionally skipped (legitimate patterns):**
- `[messageId].tsx:38` — pages router redirect in `useEffect` (standard pattern)
- `useMessageDeliveryStatus.tsx:78` — `useEffect` for toast on error state from React Query
- `_app.tsx:42` — `useIsSsr` hook controls SSR/client render split (needed for pino-pretty workaround)
- `MessageSearch.tsx:51` — 6 `useState` calls are independent filter state (refactor not warranted)
- `MessageSearch.tsx:116` — 6 `setState` in hydration `useEffect` is a one-time URL sync guarded by ref

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run prettier` — no formatting changes
- [x] `pnpm run test` — unit tests pass (PI chain integration tests fail pre-existing, unrelated)
- [ ] Manual smoke test: search, filter, message detail pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly UI-level correctness and accessibility fixes, but it introduces render-time state synchronization (conditional `setState` during render) that could cause unexpected re-render behavior if edge cases aren’t covered.
> 
> **Overview**
> Addresses React Doctor findings across the UI by adding missing image `alt` attributes (e.g., `TokenIcon`, OG image background) and replacing unassociated `<label>` elements with `<span>`.
> 
> Improves React state correctness/perf by lazily initializing filter state in `MessageSearch`, syncing `DatetimeSelector` local state when props change, and updating `ContentDetailsCard` to sync `bodyDecodeType` when `decodedBody` changes without an effect.
> 
> Reduces rendering warnings and minor perf issues by using stable/composite React keys in message cards, extracting a module-level default for `igpPayments`, and parallelizing block explorer link lookups with `Promise.all` in `WarpTransferDetailsCard`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a382a8219d072b84017206a63b08d8dc4058b0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->