### PR TITLE
feat: show distinct origin/destination tokens in warp transfer views

### DIFF
--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -167,6 +167,10 @@ export const MessageSummaryRow = memo(function MessageSummaryRow({
     () => parseWarpRouteMessageDetails(message, warpRouteChainAddressMap, chainMetadataResolver),
     [message, warpRouteChainAddressMap, chainMetadataResolver],
   );
+  const isDifferentWarpToken = warpRouteDetails
+    ? warpRouteDetails.originToken.symbol !== warpRouteDetails.destinationToken.symbol ||
+      warpRouteDetails.originToken.logoURI !== warpRouteDetails.destinationToken.logoURI
+    : false;
   return (
     <>
       <LinkCell
@@ -235,7 +239,7 @@ export const MessageSummaryRow = memo(function MessageSummaryRow({
       >
         {warpRouteDetails ? (
           <>
-            {warpRouteDetails.originToken.symbol !== warpRouteDetails.destinationToken.symbol ? (
+            {isDifferentWarpToken ? (
               <div className="relative flex-shrink-0" style={{ width: 26, height: 20 }}>
                 <div className="absolute left-0" style={{ top: -1 }}>
                   <TokenIcon token={warpRouteDetails.originToken} size={16} />
@@ -253,7 +257,7 @@ export const MessageSummaryRow = memo(function MessageSummaryRow({
             <div
               className={styles.iconText}
               data-tooltip-id="root-tooltip"
-              data-tooltip-content={`${warpRouteDetails.amount} ${warpRouteDetails.originToken.symbol}${warpRouteDetails.originToken.symbol !== warpRouteDetails.destinationToken.symbol ? ` → ${warpRouteDetails.destinationToken.symbol}` : ''}`}
+              data-tooltip-content={`${warpRouteDetails.amount} ${warpRouteDetails.originToken.symbol}${isDifferentWarpToken ? ` → ${warpRouteDetails.destinationToken.symbol}` : ''}`}
             >
               {formatAmountCompact(warpRouteDetails.amount)} {warpRouteDetails.originToken.symbol}
             </div>

--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -235,11 +235,25 @@ export const MessageSummaryRow = memo(function MessageSummaryRow({
       >
         {warpRouteDetails ? (
           <>
-            <TokenIcon token={warpRouteDetails.originToken} size={20} />
+            {warpRouteDetails.originToken.symbol !== warpRouteDetails.destinationToken.symbol ? (
+              <div className="relative flex-shrink-0" style={{ width: 26, height: 20 }}>
+                <div className="absolute left-0" style={{ top: -1 }}>
+                  <TokenIcon token={warpRouteDetails.originToken} size={16} />
+                </div>
+                <div
+                  className="absolute right-0 rounded-full ring-1 ring-white"
+                  style={{ bottom: -1 }}
+                >
+                  <TokenIcon token={warpRouteDetails.destinationToken} size={16} />
+                </div>
+              </div>
+            ) : (
+              <TokenIcon token={warpRouteDetails.originToken} size={20} />
+            )}
             <div
               className={styles.iconText}
               data-tooltip-id="root-tooltip"
-              data-tooltip-content={`${warpRouteDetails.amount} ${warpRouteDetails.originToken.symbol}`}
+              data-tooltip-content={`${warpRouteDetails.amount} ${warpRouteDetails.originToken.symbol}${warpRouteDetails.originToken.symbol !== warpRouteDetails.destinationToken.symbol ? ` → ${warpRouteDetails.destinationToken.symbol}` : ''}`}
             >
               {formatAmountCompact(warpRouteDetails.amount)} {warpRouteDetails.originToken.symbol}
             </div>

--- a/src/features/messages/cards/KeyValueRow.tsx
+++ b/src/features/messages/cards/KeyValueRow.tsx
@@ -11,12 +11,14 @@ interface Props {
   displayWidth?: string;
   subDisplay?: string;
   showCopy?: boolean;
+  copyValue?: string;
   blurValue?: boolean;
   classes?: string;
   allowZeroish?: boolean;
   link?: string | null;
   copyButtonClasses?: string | null;
   truncateMiddle?: boolean;
+  tooltip?: string;
 }
 
 export const KeyValueRow = memo(function KeyValueRow({
@@ -26,12 +28,14 @@ export const KeyValueRow = memo(function KeyValueRow({
   displayWidth,
   subDisplay,
   showCopy,
+  copyValue,
   blurValue,
   classes,
   allowZeroish = false,
   link,
   copyButtonClasses = '',
   truncateMiddle = false,
+  tooltip,
 }: Props) {
   const useFallbackVal = isZeroish(display) && !allowZeroish;
   const displayValue = !useFallbackVal
@@ -44,13 +48,17 @@ export const KeyValueRow = memo(function KeyValueRow({
     <div className={`flex items-center gap-2 font-light ${classes}`}>
       <label className={`shrink-0 text-sm text-gray-500 ${labelWidth}`}>{label}</label>
       <div className={`flex min-w-0 flex-1 items-center ${displayWidth || ''}`}>
-        <span className={`min-w-0 truncate font-mono text-sm ${blurValue && 'blur-xs'}`}>
+        <span
+          className={`min-w-0 truncate font-mono text-sm ${blurValue && 'blur-xs'}`}
+          data-tooltip-id={tooltip ? 'root-tooltip' : undefined}
+          data-tooltip-content={tooltip}
+        >
           {displayValue}
           {subDisplay && !useFallbackVal && <span className="ml-2 text-xs">{subDisplay}</span>}
         </span>
         {showCopy && !useFallbackVal && (
           <CopyButton
-            copyValue={display}
+            copyValue={copyValue || display}
             width={12}
             height={12}
             className={`ml-1.5 shrink-0 opacity-60 ${copyButtonClasses}`}

--- a/src/features/messages/cards/WarpTransferDetailsCard.tsx
+++ b/src/features/messages/cards/WarpTransferDetailsCard.tsx
@@ -90,30 +90,34 @@ export function WarpTransferDetailsCard({ message, warpRouteDetails, blur }: Pro
           <div className="space-y-2">
             <KeyValueRow
               label="Amount:"
-              labelWidth="w-40 sm:w-48"
+              labelWidth="w-28 sm:w-32"
               display={`${amount} ${originToken.symbol}`}
               blurValue={blur}
               showCopy
             />
             <KeyValueRow
-              label={`Origin token (${originToken.symbol}):`}
-              labelWidth="w-40 sm:w-48"
-              display={originToken.addressOrDenom}
+              label="Origin token:"
+              labelWidth="w-28 sm:w-32"
+              display={originToken.symbol}
+              tooltip={originToken.addressOrDenom}
+              copyValue={originToken.addressOrDenom}
               blurValue={blur}
               link={blockExplorerAddressUrls.originToken}
               showCopy
             />
             <KeyValueRow
-              label={`Destination token (${destinationToken.symbol}):`}
-              labelWidth="w-40 sm:w-48"
-              display={destinationToken.addressOrDenom}
+              label="Destination token:"
+              labelWidth="w-28 sm:w-32"
+              display={destinationToken.symbol}
+              tooltip={destinationToken.addressOrDenom}
+              copyValue={destinationToken.addressOrDenom}
               blurValue={blur}
               link={blockExplorerAddressUrls.destinationToken}
               showCopy
             />
             <KeyValueRow
               label="Transfer recipient:"
-              labelWidth="w-40 sm:w-48"
+              labelWidth="w-28 sm:w-32"
               display={transferRecipient}
               blurValue={blur}
               link={blockExplorerAddressUrls.transferRecipient}

--- a/src/features/messages/cards/WarpTransferDetailsCard.tsx
+++ b/src/features/messages/cards/WarpTransferDetailsCard.tsx
@@ -1,3 +1,4 @@
+import type { TokenArgs } from '@hyperlane-xyz/sdk';
 import { Tooltip } from '@hyperlane-xyz/widgets';
 import { useMemo } from 'react';
 
@@ -56,6 +57,9 @@ export function WarpTransferDetailsCard({ message, warpRouteDetails, blur }: Pro
 
   const { amount, transferRecipient, originToken, destinationToken } = warpRouteDetails;
   const isCollateral = isCollateralRoute(destinationToken.standard);
+  const isDifferentToken =
+    originToken.symbol !== destinationToken.symbol ||
+    originToken.logoURI !== destinationToken.logoURI;
 
   return (
     <SectionCard
@@ -70,11 +74,11 @@ export function WarpTransferDetailsCard({ message, warpRouteDetails, blur }: Pro
     >
       <div className="flex gap-4 sm:gap-6">
         {/* Token Logo Column */}
-        {warpRouteDetails.originToken.logoURI && (
-          <div className="flex flex-shrink-0 items-center justify-center">
-            <TokenIcon token={warpRouteDetails.originToken} size={80} />
-          </div>
-        )}
+        <TokenLogos
+          originToken={originToken}
+          destinationToken={destinationToken}
+          isDifferentToken={isDifferentToken}
+        />
         {/* Details Column */}
         <div className="min-w-0 flex-1 space-y-4">
           {isCollateral && (
@@ -86,22 +90,22 @@ export function WarpTransferDetailsCard({ message, warpRouteDetails, blur }: Pro
           <div className="space-y-2">
             <KeyValueRow
               label="Amount:"
-              labelWidth="w-28 sm:w-32"
+              labelWidth="w-40 sm:w-48"
               display={`${amount} ${originToken.symbol}`}
               blurValue={blur}
               showCopy
             />
             <KeyValueRow
-              label="Origin token:"
-              labelWidth="w-28 sm:w-32"
+              label={`Origin token (${originToken.symbol}):`}
+              labelWidth="w-40 sm:w-48"
               display={originToken.addressOrDenom}
               blurValue={blur}
               link={blockExplorerAddressUrls.originToken}
               showCopy
             />
             <KeyValueRow
-              label="Destination token:"
-              labelWidth="w-28 sm:w-32"
+              label={`Destination token (${destinationToken.symbol}):`}
+              labelWidth="w-40 sm:w-48"
               display={destinationToken.addressOrDenom}
               blurValue={blur}
               link={blockExplorerAddressUrls.destinationToken}
@@ -109,7 +113,7 @@ export function WarpTransferDetailsCard({ message, warpRouteDetails, blur }: Pro
             />
             <KeyValueRow
               label="Transfer recipient:"
-              labelWidth="w-28 sm:w-32"
+              labelWidth="w-40 sm:w-48"
               display={transferRecipient}
               blurValue={blur}
               link={blockExplorerAddressUrls.transferRecipient}
@@ -119,5 +123,42 @@ export function WarpTransferDetailsCard({ message, warpRouteDetails, blur }: Pro
         </div>
       </div>
     </SectionCard>
+  );
+}
+
+function TokenLogos({
+  originToken,
+  destinationToken,
+  isDifferentToken,
+}: {
+  originToken: TokenArgs;
+  destinationToken: TokenArgs;
+  isDifferentToken: boolean;
+}) {
+  const hasOriginLogo = !!originToken.logoURI;
+  const hasDestLogo = !!destinationToken.logoURI;
+
+  if (!hasOriginLogo && !hasDestLogo) return null;
+
+  if (!isDifferentToken) {
+    const token = hasOriginLogo ? originToken : destinationToken;
+    return (
+      <div className="flex flex-shrink-0 items-center justify-center">
+        <TokenIcon token={token} size={80} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-shrink-0 items-center justify-center">
+      <div className="relative" style={{ width: 73, height: 73 }}>
+        <div className="absolute left-0 top-0">
+          <TokenIcon token={originToken} size={48} />
+        </div>
+        <div className="absolute bottom-0 right-0 rounded-full ring-2 ring-white">
+          <TokenIcon token={destinationToken} size={48} />
+        </div>
+      </div>
+    </div>
   );
 }

--- a/src/features/messages/cards/WarpTransferDetailsCard.tsx
+++ b/src/features/messages/cards/WarpTransferDetailsCard.tsx
@@ -139,16 +139,10 @@ function TokenLogos({
   destinationToken: TokenArgs;
   isDifferentToken: boolean;
 }) {
-  const hasOriginLogo = !!originToken.logoURI;
-  const hasDestLogo = !!destinationToken.logoURI;
-
-  if (!hasOriginLogo && !hasDestLogo) return null;
-
   if (!isDifferentToken) {
-    const token = hasOriginLogo ? originToken : destinationToken;
     return (
       <div className="flex flex-shrink-0 items-center justify-center">
-        <TokenIcon token={token} size={80} />
+        <TokenIcon token={originToken} size={80} />
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- **Detail page**: Show overlapping diagonal token icons when origin and destination are different assets. Token rows display symbol instead of address, with address available via tooltip and copy button.
- **Listing table**: Show overlapping mini token icons when tokens differ. Hover tooltip shows `amount SYMBOL → DEST_SYMBOL`.


images:

<img width="946" height="225" alt="image" src="https://github.com/user-attachments/assets/ecc11084-5670-4073-beef-a5bbcbf66f15" />
<img width="933" height="241" alt="image" src="https://github.com/user-attachments/assets/95787004-fcad-4cff-b2cc-3fe7f9cc81da" />
<img width="980" height="228" alt="image" src="https://github.com/user-attachments/assets/ba832285-3ca8-4243-8f4e-d06de9bf289a" />
<img width="930" height="111" alt="image" src="https://github.com/user-attachments/assets/3c89c364-57c2-4f23-a986-395f317ab1bd" />
<img width="915" height="108" alt="image" src="https://github.com/user-attachments/assets/0c4d7310-cb3b-418c-8c6b-fedf690c76da" />
<img width="951" height="102" alt="image" src="https://github.com/user-attachments/assets/68e644d3-646c-41d1-b703-90d5f9f6a498" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)