### PR TITLE
feat: show received amount for warp transfers with different scales

### DIFF
--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -171,6 +171,7 @@ export const MessageSummaryRow = memo(function MessageSummaryRow({
     ? warpRouteDetails.originToken.symbol !== warpRouteDetails.destinationToken.symbol ||
       warpRouteDetails.originToken.logoURI !== warpRouteDetails.destinationToken.logoURI
     : false;
+  const showWarpTooltip = isDifferentWarpToken || !!warpRouteDetails?.destAmount;
   return (
     <>
       <LinkCell
@@ -257,7 +258,7 @@ export const MessageSummaryRow = memo(function MessageSummaryRow({
             <div
               className={styles.iconText}
               data-tooltip-id="root-tooltip"
-              data-tooltip-content={`${warpRouteDetails.amount} ${warpRouteDetails.originToken.symbol}${isDifferentWarpToken ? ` → ${warpRouteDetails.destinationToken.symbol}` : ''}`}
+              data-tooltip-content={`${formatAmountCompact(warpRouteDetails.amount)} ${warpRouteDetails.originToken.symbol}${showWarpTooltip ? ` → ${formatAmountCompact(warpRouteDetails.destAmount ?? warpRouteDetails.amount)} ${warpRouteDetails.destinationToken.symbol}` : ''}`}
             >
               {formatAmountCompact(warpRouteDetails.amount)} {warpRouteDetails.originToken.symbol}
             </div>

--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -171,10 +171,10 @@ export const MessageSummaryRow = memo(function MessageSummaryRow({
     ? warpRouteDetails.originToken.symbol !== warpRouteDetails.destinationToken.symbol ||
       warpRouteDetails.originToken.logoURI !== warpRouteDetails.destinationToken.logoURI
     : false;
-  const showWarpTooltip = isDifferentWarpToken || !isNullish(warpRouteDetails?.destAmount);
+  const showDestInTooltip = isDifferentWarpToken || !isNullish(warpRouteDetails?.destAmount);
   const warpTooltipContent = warpRouteDetails
     ? `${formatAmountCompact(warpRouteDetails.amount)} ${warpRouteDetails.originToken.symbol}${
-        showWarpTooltip
+        showDestInTooltip
           ? ` → ${formatAmountCompact(warpRouteDetails.destAmount ?? warpRouteDetails.amount)} ${warpRouteDetails.destinationToken.symbol}`
           : ''
       }`

--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -1,4 +1,4 @@
-import { shortenAddress } from '@hyperlane-xyz/utils';
+import { isNullish, shortenAddress } from '@hyperlane-xyz/utils';
 import Image from 'next/image';
 import Link from 'next/link';
 import { NextRouter, useRouter } from 'next/router';
@@ -171,7 +171,14 @@ export const MessageSummaryRow = memo(function MessageSummaryRow({
     ? warpRouteDetails.originToken.symbol !== warpRouteDetails.destinationToken.symbol ||
       warpRouteDetails.originToken.logoURI !== warpRouteDetails.destinationToken.logoURI
     : false;
-  const showWarpTooltip = isDifferentWarpToken || !!warpRouteDetails?.destAmount;
+  const showWarpTooltip = isDifferentWarpToken || !isNullish(warpRouteDetails?.destAmount);
+  const warpTooltipContent = warpRouteDetails
+    ? `${formatAmountCompact(warpRouteDetails.amount)} ${warpRouteDetails.originToken.symbol}${
+        showWarpTooltip
+          ? ` → ${formatAmountCompact(warpRouteDetails.destAmount ?? warpRouteDetails.amount)} ${warpRouteDetails.destinationToken.symbol}`
+          : ''
+      }`
+    : '';
   return (
     <>
       <LinkCell
@@ -258,7 +265,7 @@ export const MessageSummaryRow = memo(function MessageSummaryRow({
             <div
               className={styles.iconText}
               data-tooltip-id="root-tooltip"
-              data-tooltip-content={`${formatAmountCompact(warpRouteDetails.amount)} ${warpRouteDetails.originToken.symbol}${showWarpTooltip ? ` → ${formatAmountCompact(warpRouteDetails.destAmount ?? warpRouteDetails.amount)} ${warpRouteDetails.destinationToken.symbol}` : ''}`}
+              data-tooltip-content={warpTooltipContent}
             >
               {formatAmountCompact(warpRouteDetails.amount)} {warpRouteDetails.originToken.symbol}
             </div>

--- a/src/features/messages/cards/WarpTransferDetailsCard.tsx
+++ b/src/features/messages/cards/WarpTransferDetailsCard.tsx
@@ -1,4 +1,5 @@
 import type { TokenArgs } from '@hyperlane-xyz/sdk';
+import { isNullish } from '@hyperlane-xyz/utils';
 import { Tooltip } from '@hyperlane-xyz/widgets';
 import { useMemo } from 'react';
 
@@ -96,7 +97,7 @@ export function WarpTransferDetailsCard({ message, warpRouteDetails, blur }: Pro
               blurValue={blur}
               showCopy
             />
-            {destAmount && (
+            {!isNullish(destAmount) && (
               <KeyValueRow
                 label="Received amount:"
                 labelWidth="w-28 sm:w-32"

--- a/src/features/messages/cards/WarpTransferDetailsCard.tsx
+++ b/src/features/messages/cards/WarpTransferDetailsCard.tsx
@@ -94,6 +94,7 @@ export function WarpTransferDetailsCard({ message, warpRouteDetails, blur }: Pro
               label="Amount:"
               labelWidth="w-28 sm:w-32"
               display={`${formatAmountWithCommas(amount)} ${originToken.symbol}`}
+              copyValue={amount}
               blurValue={blur}
               showCopy
             />
@@ -102,6 +103,7 @@ export function WarpTransferDetailsCard({ message, warpRouteDetails, blur }: Pro
                 label="Received amount:"
                 labelWidth="w-28 sm:w-32"
                 display={`${formatAmountWithCommas(destAmount)} ${destinationToken.symbol}`}
+                copyValue={destAmount}
                 blurValue={blur}
                 showCopy
               />

--- a/src/features/messages/cards/WarpTransferDetailsCard.tsx
+++ b/src/features/messages/cards/WarpTransferDetailsCard.tsx
@@ -6,6 +6,7 @@ import { TokenIcon } from '../../../components/icons/TokenIcon';
 import { SectionCard } from '../../../components/layout/SectionCard';
 import { useChainMetadataResolver } from '../../../metadataStore';
 import { Message, MessageStub, WarpRouteDetails } from '../../../types';
+import { formatAmountWithCommas } from '../../../utils/amount';
 import { getBlockExplorerAddressUrl } from '../../../utils/url';
 import { isCollateralRoute } from '../collateral/utils';
 import { KeyValueRow } from './KeyValueRow';
@@ -55,7 +56,7 @@ export function WarpTransferDetailsCard({ message, warpRouteDetails, blur }: Pro
 
   if (!warpRouteDetails) return null;
 
-  const { amount, transferRecipient, originToken, destinationToken } = warpRouteDetails;
+  const { amount, destAmount, transferRecipient, originToken, destinationToken } = warpRouteDetails;
   const isCollateral = isCollateralRoute(destinationToken.standard);
   const isDifferentToken =
     originToken.symbol !== destinationToken.symbol ||
@@ -91,10 +92,19 @@ export function WarpTransferDetailsCard({ message, warpRouteDetails, blur }: Pro
             <KeyValueRow
               label="Amount:"
               labelWidth="w-28 sm:w-32"
-              display={`${amount} ${originToken.symbol}`}
+              display={`${formatAmountWithCommas(amount)} ${originToken.symbol}`}
               blurValue={blur}
               showCopy
             />
+            {destAmount && (
+              <KeyValueRow
+                label="Received amount:"
+                labelWidth="w-28 sm:w-32"
+                display={`${formatAmountWithCommas(destAmount)} ${destinationToken.symbol}`}
+                blurValue={blur}
+                showCopy
+              />
+            )}
             <KeyValueRow
               label="Origin token:"
               labelWidth="w-28 sm:w-32"

--- a/src/features/messages/utils.test.ts
+++ b/src/features/messages/utils.test.ts
@@ -1,3 +1,4 @@
+import { type ChainMetadata, TokenStandard } from '@hyperlane-xyz/sdk';
 import { ProtocolType } from '@hyperlane-xyz/utils';
 
 import { MessageStatus, type MessageStub, type WarpRouteChainAddressMap } from '../../types';
@@ -55,7 +56,7 @@ function buildTestSetup({
     [ORIGIN_CHAIN]: {
       [SENDER_BYTES32]: {
         chainName: ORIGIN_CHAIN,
-        standard: 'EvmHypCollateral' as any,
+        standard: TokenStandard.EvmHypCollateral,
         addressOrDenom: SENDER,
         decimals: originToken.decimals,
         symbol: 'ORIG',
@@ -67,7 +68,7 @@ function buildTestSetup({
     [DEST_CHAIN]: {
       [RECIPIENT_BYTES32]: {
         chainName: DEST_CHAIN,
-        standard: 'EvmHypSynthetic' as any,
+        standard: TokenStandard.EvmHypSynthetic,
         addressOrDenom: RECIPIENT,
         decimals: destToken.decimals,
         symbol: 'DEST',
@@ -78,14 +79,22 @@ function buildTestSetup({
     },
   };
 
+  const originMetadata = {
+    name: ORIGIN_CHAIN,
+    chainId: 1,
+    domainId: ORIGIN_DOMAIN,
+    protocol: ProtocolType.Ethereum,
+  } as ChainMetadata;
+  const destMetadata = {
+    name: DEST_CHAIN,
+    chainId: 2,
+    domainId: DEST_DOMAIN,
+    protocol: ProtocolType.Ethereum,
+  } as ChainMetadata;
   const chainMetadataResolver = {
-    tryGetChainMetadata: (chain: string | number) => {
-      if (chain === ORIGIN_DOMAIN) {
-        return { name: ORIGIN_CHAIN, protocol: ProtocolType.Ethereum } as any;
-      }
-      if (chain === DEST_DOMAIN) {
-        return { name: DEST_CHAIN, protocol: ProtocolType.Ethereum } as any;
-      }
+    tryGetChainMetadata: (chain: string | number): ChainMetadata | undefined => {
+      if (chain === ORIGIN_DOMAIN) return originMetadata;
+      if (chain === DEST_DOMAIN) return destMetadata;
       return undefined;
     },
   };
@@ -108,7 +117,8 @@ describe('parseWarpRouteMessageDetails', () => {
         chainMetadataResolver,
       );
 
-      expect(result?.destAmount).toBeNull();
+      expect(result).toBeDefined();
+      expect(result!.destAmount).toBeNull();
     });
 
     it('returns null when scales are equivalent fractions', () => {
@@ -125,7 +135,8 @@ describe('parseWarpRouteMessageDetails', () => {
         chainMetadataResolver,
       );
 
-      expect(result?.destAmount).toBeNull();
+      expect(result).toBeDefined();
+      expect(result!.destAmount).toBeNull();
     });
 
     it('computes destAmount using dest scale when scales differ (VRA-style)', () => {
@@ -144,8 +155,51 @@ describe('parseWarpRouteMessageDetails', () => {
         chainMetadataResolver,
       );
 
-      expect(result?.amount).toBe('1');
-      expect(result?.destAmount).toBe('10');
+      expect(result).toBeDefined();
+      expect(result!.amount).toBe('1');
+      expect(result!.destAmount).toBe('10');
+    });
+
+    it('computes destAmount when only origin has scale (BSC USDT scale-down style)', () => {
+      // Origin: 18 dec with scale {1, 1e12} (scale-down). Dest: 6 dec, no scale.
+      // Sending 1 USDT from origin: localAmount=1e18, message=1e18*1/1e12=1e6.
+      // Dest (no scale): localAmount = 1e6 → fromWei(1e6, 6) = "1".
+      const { message, warpRouteChainAddressMap, chainMetadataResolver } = buildTestSetup({
+        originToken: { decimals: 18, scale: { numerator: 1, denominator: 1_000_000_000_000 } },
+        destToken: { decimals: 6 },
+        messageAmount: 1_000_000n,
+      });
+
+      const result = parseWarpRouteMessageDetails(
+        message,
+        warpRouteChainAddressMap,
+        chainMetadataResolver,
+      );
+
+      expect(result).toBeDefined();
+      expect(result!.amount).toBe('1');
+      expect(result!.destAmount).toBe('1');
+    });
+
+    it('computes destAmount when only dest has scale (same decimals)', () => {
+      // Origin: 18 dec, no scale. Dest: 18 dec with scale-down {1, 10}.
+      // Sending 1 token from origin: localAmount=1e18, message=1e18 (no scale).
+      // Dest: localAmount = 1e18 * 10 / 1 = 1e19 → fromWei(1e19, 18) = "10".
+      const { message, warpRouteChainAddressMap, chainMetadataResolver } = buildTestSetup({
+        originToken: { decimals: 18 },
+        destToken: { decimals: 18, scale: { numerator: 1, denominator: 10 } },
+        messageAmount: 10n ** 18n,
+      });
+
+      const result = parseWarpRouteMessageDetails(
+        message,
+        warpRouteChainAddressMap,
+        chainMetadataResolver,
+      );
+
+      expect(result).toBeDefined();
+      expect(result!.amount).toBe('1');
+      expect(result!.destAmount).toBe('10');
     });
   });
 });

--- a/src/features/messages/utils.test.ts
+++ b/src/features/messages/utils.test.ts
@@ -1,0 +1,151 @@
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { MessageStatus, type MessageStub, type WarpRouteChainAddressMap } from '../../types';
+import { parseWarpRouteMessageDetails } from './utils';
+
+const ORIGIN_DOMAIN = 1;
+const DEST_DOMAIN = 2;
+const ORIGIN_CHAIN = 'originchain';
+const DEST_CHAIN = 'destchain';
+const SENDER = '0x1111111111111111111111111111111111111111';
+const RECIPIENT = '0x2222222222222222222222222222222222222222';
+const SENDER_BYTES32 = '0x000000000000000000000000' + SENDER.slice(2);
+const RECIPIENT_BYTES32 = '0x000000000000000000000000' + RECIPIENT.slice(2);
+
+interface TokenConfig {
+  decimals: number;
+  scale?: number | { numerator: number; denominator: number };
+  wireDecimals?: number;
+}
+
+function buildTestSetup({
+  originToken,
+  destToken,
+  messageAmount,
+}: {
+  originToken: TokenConfig;
+  destToken: TokenConfig;
+  messageAmount: bigint;
+}) {
+  const wireDecimals = Math.max(originToken.decimals, destToken.decimals);
+
+  // Message body: 32 bytes recipient + 32 bytes amount
+  const amountHex = messageAmount.toString(16).padStart(64, '0');
+  const recipientHex = RECIPIENT_BYTES32.slice(2);
+  const body = '0x' + recipientHex + amountHex;
+
+  const message: MessageStub = {
+    status: MessageStatus.Delivered,
+    id: 'test-id',
+    msgId: '0xabc',
+    nonce: 1,
+    sender: SENDER_BYTES32,
+    recipient: RECIPIENT_BYTES32,
+    originChainId: 1,
+    originDomainId: ORIGIN_DOMAIN,
+    destinationChainId: 2,
+    destinationDomainId: DEST_DOMAIN,
+    origin: { timestamp: 0, hash: '0x0', from: SENDER, to: RECIPIENT },
+    body,
+  };
+
+  // Token map keys use the full bytes32 format since sender/recipient in messages
+  // are bytes32 and getTokenFromWarpRouteChainAddressMap matches with endsWith
+  const warpRouteChainAddressMap: WarpRouteChainAddressMap = {
+    [ORIGIN_CHAIN]: {
+      [SENDER_BYTES32]: {
+        chainName: ORIGIN_CHAIN,
+        standard: 'EvmHypCollateral' as any,
+        addressOrDenom: SENDER,
+        decimals: originToken.decimals,
+        symbol: 'ORIG',
+        name: 'Origin',
+        scale: originToken.scale,
+        wireDecimals: originToken.wireDecimals ?? wireDecimals,
+      },
+    },
+    [DEST_CHAIN]: {
+      [RECIPIENT_BYTES32]: {
+        chainName: DEST_CHAIN,
+        standard: 'EvmHypSynthetic' as any,
+        addressOrDenom: RECIPIENT,
+        decimals: destToken.decimals,
+        symbol: 'DEST',
+        name: 'Destination',
+        scale: destToken.scale,
+        wireDecimals: destToken.wireDecimals ?? wireDecimals,
+      },
+    },
+  };
+
+  const chainMetadataResolver = {
+    tryGetChainMetadata: (chain: string | number) => {
+      if (chain === ORIGIN_DOMAIN) {
+        return { name: ORIGIN_CHAIN, protocol: ProtocolType.Ethereum } as any;
+      }
+      if (chain === DEST_DOMAIN) {
+        return { name: DEST_CHAIN, protocol: ProtocolType.Ethereum } as any;
+      }
+      return undefined;
+    },
+  };
+
+  return { message, warpRouteChainAddressMap, chainMetadataResolver };
+}
+
+describe('parseWarpRouteMessageDetails', () => {
+  describe('destAmount', () => {
+    it('returns null when both tokens have no scale', () => {
+      const { message, warpRouteChainAddressMap, chainMetadataResolver } = buildTestSetup({
+        originToken: { decimals: 18 },
+        destToken: { decimals: 18 },
+        messageAmount: 10n ** 18n,
+      });
+
+      const result = parseWarpRouteMessageDetails(
+        message,
+        warpRouteChainAddressMap,
+        chainMetadataResolver,
+      );
+
+      expect(result?.destAmount).toBeNull();
+    });
+
+    it('returns null when scales are equivalent fractions', () => {
+      // origin {2,4} and dest {1,2} both normalize to 1/2 — equal
+      const { message, warpRouteChainAddressMap, chainMetadataResolver } = buildTestSetup({
+        originToken: { decimals: 18, scale: { numerator: 2, denominator: 4 } },
+        destToken: { decimals: 18, scale: { numerator: 1, denominator: 2 } },
+        messageAmount: 10n ** 18n,
+      });
+
+      const result = parseWarpRouteMessageDetails(
+        message,
+        warpRouteChainAddressMap,
+        chainMetadataResolver,
+      );
+
+      expect(result?.destAmount).toBeNull();
+    });
+
+    it('computes destAmount using dest scale when scales differ (VRA-style)', () => {
+      // VRA: origin scale=10, dest scale=1, both 18 decimals.
+      // Sending 1 VRA from origin: localAmount=1e18, message=1e18*10=1e19.
+      // Dest: localAmount = 1e19 * 1 / 1 = 1e19 → fromWei(1e19, 18) = "10".
+      const { message, warpRouteChainAddressMap, chainMetadataResolver } = buildTestSetup({
+        originToken: { decimals: 18, scale: 10 },
+        destToken: { decimals: 18, scale: 1 },
+        messageAmount: 10n ** 19n,
+      });
+
+      const result = parseWarpRouteMessageDetails(
+        message,
+        warpRouteChainAddressMap,
+        chainMetadataResolver,
+      );
+
+      expect(result?.amount).toBe('1');
+      expect(result?.destAmount).toBe('10');
+    });
+  });
+});

--- a/src/features/messages/utils.ts
+++ b/src/features/messages/utils.ts
@@ -70,12 +70,13 @@ export function parseWarpRouteMessageDetails(
     });
     const amount = fromWei(amountParts.amount.toString(), amountParts.decimals);
 
-    // Compute destination amount when scales differ
+    // Compute destination amount when scales differ. Always use destinationToken.decimals
+    // (not wireDecimals): after applying dest scale, the local amount is in dest's native
+    // decimal space, which is how the receiving user sees their balance.
     let destAmount: string | null = null;
     if (!scalesEqual(originToken.scale, destinationToken.scale)) {
-      const destDecimals = getEffectiveDecimals(destinationToken, originToken);
       const destAmountParts = getWarpRouteAmountParts(parsedMessage.amount, {
-        decimals: destDecimals,
+        decimals: destinationToken.decimals,
         scale: destinationToken.scale,
       });
       destAmount = fromWei(destAmountParts.amount.toString(), destAmountParts.decimals);

--- a/src/features/messages/utils.ts
+++ b/src/features/messages/utils.ts
@@ -72,10 +72,7 @@ export function parseWarpRouteMessageDetails(
 
     // Compute destination amount when scales differ
     let destAmount: string | null = null;
-    if (
-      (originToken.scale || destinationToken.scale) &&
-      !scalesEqual(originToken.scale, destinationToken.scale)
-    ) {
+    if (!scalesEqual(originToken.scale, destinationToken.scale)) {
       const destDecimals = getEffectiveDecimals(destinationToken, originToken);
       const destAmountParts = getWarpRouteAmountParts(parsedMessage.amount, {
         decimals: destDecimals,

--- a/src/features/messages/utils.ts
+++ b/src/features/messages/utils.ts
@@ -1,3 +1,4 @@
+import { scalesEqual } from '@hyperlane-xyz/sdk';
 import {
   bytesToProtocolAddress,
   fromBase64,
@@ -67,12 +68,28 @@ export function parseWarpRouteMessageDetails(
       decimals: effectiveDecimals,
       scale: originToken.scale,
     });
+    const amount = fromWei(amountParts.amount.toString(), amountParts.decimals);
+
+    // Compute destination amount when scales differ
+    let destAmount: string | null = null;
+    if (
+      (originToken.scale || destinationToken.scale) &&
+      !scalesEqual(originToken.scale, destinationToken.scale)
+    ) {
+      const destDecimals = getEffectiveDecimals(destinationToken, originToken);
+      const destAmountParts = getWarpRouteAmountParts(parsedMessage.amount, {
+        decimals: destDecimals,
+        scale: destinationToken.scale,
+      });
+      destAmount = fromWei(destAmountParts.amount.toString(), destAmountParts.decimals);
+    }
 
     return {
-      amount: fromWei(amountParts.amount.toString(), amountParts.decimals),
+      amount,
+      destAmount,
       transferRecipient: address,
-      originToken: originToken,
-      destinationToken: destinationToken,
+      originToken,
+      destinationToken,
     };
   } catch (err) {
     logger.error(`Error parsing warp route details for ${message.id}:`, err);

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,7 @@ export type TokenArgsWithWireDecimals = TokenArgs & { wireDecimals: number };
 
 export interface WarpRouteDetails {
   amount: string;
+  destAmount: string | null;
   transferRecipient: string;
   originToken: TokenArgsWithWireDecimals;
   destinationToken: TokenArgsWithWireDecimals;


### PR DESCRIPTION
## Summary
Shows the destination received amount in the explorer when origin and destination tokens have different scales (e.g., VRA BSC scale=10 → ETH scale=1, or BSC USDT 18-dec scale-down).

## Changes

### Transfer details card
- New "Received amount" row appears below "Amount" when scales differ
- Both amounts formatted with comma separators via `formatAmountWithCommas`

### Message list tooltip
- Tooltip now shows amount conversion: `1 VRA → 10 VRA`
- Uses `formatAmountCompact` for both sides (K/M/B notation)
- Appears when amounts differ OR when token symbols differ (previously only symbols)

### Computation
- `destAmount` computed in `parseWarpRouteMessageDetails` using existing `getWarpRouteAmountParts` with dest token's scale and `getEffectiveDecimals` with swapped token order
- Only computed when `scalesEqual(originToken.scale, destinationToken.scale)` is false
- `null` for same-scale routes (no UI change)

## Files changed
- `src/types.ts` — added `destAmount: string | null` to `WarpRouteDetails`
- `src/features/messages/utils.ts` — compute destAmount in `parseWarpRouteMessageDetails`
- `src/features/messages/cards/WarpTransferDetailsCard.tsx` — received amount row + comma formatting
- `src/features/messages/MessageTable.tsx` — tooltip with formatted amounts

## Related
- hyperlane-xyz/hyperlane-monorepo#8594 — SDK scale helpers (`scalesEqual`)
- hyperlane-xyz/hyperlane-warp-ui-template#1053 — Same feature in warp-ui

🤖 Generated with [Claude Code](https://claude.com/claude-code)