### PR TITLE
feat: show received amount when token symbols differ

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/src/features/messages/cards/WarpTransferDetailsCard.tsx
+++ b/src/features/messages/cards/WarpTransferDetailsCard.tsx
@@ -98,12 +98,12 @@ export function WarpTransferDetailsCard({ message, warpRouteDetails, blur }: Pro
               blurValue={blur}
               showCopy
             />
-            {!isNullish(destAmount) && (
+            {(!isNullish(destAmount) || isDifferentToken) && (
               <KeyValueRow
                 label="Received amount:"
                 labelWidth="w-28 sm:w-32"
-                display={`${formatAmountWithCommas(destAmount)} ${destinationToken.symbol}`}
-                copyValue={destAmount}
+                display={`${formatAmountWithCommas(destAmount ?? amount)} ${destinationToken.symbol}`}
+                copyValue={destAmount ?? amount}
                 blurValue={blur}
                 showCopy
               />


### PR DESCRIPTION
## Summary
Extends the \"Received amount\" row in the transfer details to also appear when origin and destination token **symbols** differ (not just when scales differ).

## Before
The \"Received amount\" row only appeared when \`destAmount\` was set — which only happens when origin/dest scales differ.

## After
The row now appears whenever:
- \`destAmount\` is set (scales differ → different amount), **OR**
- Token symbols/logos differ (same scale but different tokens)

When \`destAmount\` is null (same scale), falls back to the origin \`amount\` with the destination token's symbol. Example: a \"1 USDT → 1 USDC\" route now shows:
- Amount: 1 USDT
- Received amount: 1 USDC

## Related
- Follow-up to #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)