### PR TITLE
docs: codify explorer runtime review guidelines

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -23,6 +23,9 @@
 - Preserve intentional metadata-only vs provider-backed boundaries; don't collapse `metadataStore.ts` back into `store.ts` unless there is a concrete functional need
 - **Deduplicate** - Move repeated code/types to shared files
 - **Extract utilities** - Shared functions belong in utils packages
+- **Prefer shared widgets surfaces** - If behavior belongs in widgets, upstream/fix the shared component instead of growing Explorer-only clones
+- **Narrow runtime surfaces without dropping parity** - Keep supported protocol behavior; if a broad import is the problem, prefer a narrower runtime subpath over removing support
+- **Keep last-known-good provider state** - During async provider rebuilds, avoid eagerly swapping to empty placeholders if the old provider can safely remain live until replacement
 
 ## Testing
 
@@ -44,6 +47,9 @@
 - **PI chains** - Permissionless Interop chains have separate query paths in `src/features/messages/pi-queries/`
 - **Edge runtime** - Can't import @hyperlane-xyz/utils in edge runtime (API routes)
 - **Export reusable components** - Common UI patterns should be extracted
+- **Provider-backed queries need readiness + versioning** - If queries depend on the runtime provider, gate them on the ready provider and include provider version in the query key
+- **Avoid alloc-heavy store selectors** - Prefer individual Zustand selectors or shallow-equal slices over returning fresh objects each render
+- **Use shared chain menu behavior** - Chain search/filter/sort/add/edit behavior should stay aligned with widgets unless Explorer has a real product-specific divergence
 
 ## UI Consistency
 


### PR DESCRIPTION
## Summary

Codifies the review standards that [hyperlane-xyz/hyperlane-explorer#301](https://github.com/hyperlane-xyz/hyperlane-explorer/pull/301) ended up enforcing.

## What changed

- documented preference for shared widgets surfaces over Explorer-only clones
- documented narrowing runtime surfaces without dropping supported protocol parity
- documented keeping last-known-good provider state during async rebuilds
- documented readiness + version requirements for provider-backed queries
- documented avoiding alloc-heavy Zustand selectors
- documented keeping shared chain-search behavior aligned with widgets unless Explorer has a real product-specific divergence

## Why

[hyperlane-xyz/hyperlane-explorer#301](https://github.com/hyperlane-xyz/hyperlane-explorer/pull/301) established a clear metadata-first/provider-backed split and a specific set of review expectations around provider readiness, query invalidation, and upstreaming shared UI. This captures those standards in one place.

## Impact

Docs only. No runtime behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that updates review guidance; no runtime or API behavior is modified.
> 
> **Overview**
> Updates `REVIEW.md` to codify additional Explorer runtime review standards.
> 
> Adds guidance to **prefer shared widget surfaces over Explorer-only clones**, **narrow runtime imports without dropping protocol parity**, and **keep last-known-good provider state during async rebuilds**. Also documents expectations for **provider-backed query readiness + provider-versioned query keys**, avoiding alloc-heavy Zustand selectors, and keeping chain menu behavior aligned with shared widgets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad9b9d96cbdf340aacbbd2d1d21969c40d29a31b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
