### PR TITLE
fix(warpFees): support aggregator / intermediary flows

### DIFF
--- a/src/features/messages/warpFees/fetchWarpFees.test.ts
+++ b/src/features/messages/warpFees/fetchWarpFees.test.ts
@@ -91,38 +91,41 @@ describe('parseSentTransferRemoteAmount', () => {
 });
 
 describe('parseTotalTokenPulledFromUser', () => {
-  it('sums ERC20 transfers from sender to router', () => {
+  it('sums ERC20 transfers to router', () => {
     const logs = [
       makeTransferLog(SENDER, ROUTER, BigNumber.from('1000000'), TOKEN),
       makeTransferLog(SENDER, ROUTER, BigNumber.from('50000'), TOKEN),
     ];
-    const result = parseTotalTokenPulledFromUser(logs, ROUTER, TOKEN, SENDER);
+    const result = parseTotalTokenPulledFromUser(logs, ROUTER, TOKEN);
     expect(result?.eq(BigNumber.from('1050000'))).toBe(true);
   });
 
-  it('ignores transfers from a different sender (smart-wallet / intermediary)', () => {
-    const other = utils.getAddress('0x0000000000000000000000000000000000000042');
-    const logs = [makeTransferLog(other, ROUTER, BigNumber.from('1000000'), TOKEN)];
-    const result = parseTotalTokenPulledFromUser(logs, ROUTER, TOKEN, SENDER);
-    expect(result).toBeNull();
+  it('counts aggregator / intermediary pulls (from != tx.from)', () => {
+    // Aggregator / vault contract pulls tokens on the user's behalf and
+    // forwards to the router. The Transfer's `from` is the intermediary,
+    // not the user's EOA — still a legitimate pull for this message.
+    const aggregator = utils.getAddress('0x0000000000000000000000000000000000000042');
+    const logs = [makeTransferLog(aggregator, ROUTER, BigNumber.from('1000000'), TOKEN)];
+    const result = parseTotalTokenPulledFromUser(logs, ROUTER, TOKEN);
+    expect(result?.eq(BigNumber.from('1000000'))).toBe(true);
   });
 
   it('ignores transfers to other addresses', () => {
     const other = utils.getAddress('0x0000000000000000000000000000000000000003');
     const logs = [makeTransferLog(SENDER, other, BigNumber.from('1000000'), TOKEN)];
-    const result = parseTotalTokenPulledFromUser(logs, ROUTER, TOKEN, SENDER);
+    const result = parseTotalTokenPulledFromUser(logs, ROUTER, TOKEN);
     expect(result).toBeNull();
   });
 
   it('ignores transfers from a different token contract', () => {
     const otherToken = utils.getAddress('0x0000000000000000000000000000000000000099');
     const logs = [makeTransferLog(SENDER, ROUTER, BigNumber.from('1000000'), otherToken)];
-    const result = parseTotalTokenPulledFromUser(logs, ROUTER, TOKEN, SENDER);
+    const result = parseTotalTokenPulledFromUser(logs, ROUTER, TOKEN);
     expect(result).toBeNull();
   });
 
   it('returns null when no matching transfers found', () => {
-    const result = parseTotalTokenPulledFromUser([], ROUTER, TOKEN, SENDER);
+    const result = parseTotalTokenPulledFromUser([], ROUTER, TOKEN);
     expect(result).toBeNull();
   });
 
@@ -130,8 +133,18 @@ describe('parseTotalTokenPulledFromUser', () => {
     // HypERC20 synthetic: router IS the token; _transferFromSender burns from user.
     const synth = ROUTER;
     const logs = [makeTransferLog(SENDER, ZERO, BigNumber.from('5004'), synth)];
-    const result = parseTotalTokenPulledFromUser(logs, synth, synth, SENDER);
+    const result = parseTotalTokenPulledFromUser(logs, synth, synth);
     expect(result?.eq(BigNumber.from('5004'))).toBe(true);
+  });
+
+  it('counts intermediary-initiated synthetic burns (Transfer aggregator→0x0)', () => {
+    // User calls an aggregator which eventually burns on the synthetic router.
+    // The burn's `from` is the intermediary, not the user's EOA.
+    const synth = ROUTER;
+    const intermediary = utils.getAddress('0x00000000000000000000000000000000000abcde');
+    const logs = [makeTransferLog(intermediary, ZERO, BigNumber.from('751748260'), synth)];
+    const result = parseTotalTokenPulledFromUser(logs, synth, synth);
+    expect(result?.eq(BigNumber.from('751748260'))).toBe(true);
   });
 
   it('ignores mints (Transfer 0x0→feeRecipient) in synthetic fee flow', () => {
@@ -140,20 +153,20 @@ describe('parseTotalTokenPulledFromUser', () => {
       makeTransferLog(SENDER, ZERO, BigNumber.from('5004'), synth), // burn — counted
       makeTransferLog(ZERO, FEE_RECIPIENT, BigNumber.from('4'), synth), // mint — ignored
     ];
-    const result = parseTotalTokenPulledFromUser(logs, synth, synth, SENDER);
+    const result = parseTotalTokenPulledFromUser(logs, synth, synth);
     expect(result?.eq(BigNumber.from('5004'))).toBe(true);
   });
 
   it('ignores wrapper-token mints to router (xERC20/lockbox routes)', () => {
     // Ethereum USDT → Igra: user pulls 200 USDT to router; router receives
     // 180e18 mint of a wrapper token. Only the user→router USDT transfer
-    // should count — the mint has `from == 0x0`, not sender.
+    // should count — the mint has `from == 0x0`.
     const wrapper = utils.getAddress('0x00000000000000000000000000000000beef0001');
     const logs = [
       makeTransferLog(SENDER, ROUTER, BigNumber.from('200000000'), TOKEN), // 200 USDT
       makeTransferLog(ZERO, ROUTER, BigNumber.from('180000000000000000000'), wrapper), // 180e18 mint
     ];
-    const result = parseTotalTokenPulledFromUser(logs, ROUTER, TOKEN, SENDER);
+    const result = parseTotalTokenPulledFromUser(logs, ROUTER, TOKEN);
     expect(result?.eq(BigNumber.from('200000000'))).toBe(true);
   });
 });
@@ -189,7 +202,7 @@ describe('sliceLogsForMessage', () => {
     const slice2 = sliceLogsForMessage(logs, MSG_ID_2);
     expect(slice2).toHaveLength(3);
     const sent = parseSentTransferRemoteAmount(slice2!, ROUTER);
-    const total = parseTotalTokenPulledFromUser(slice2!, ROUTER, TOKEN, SENDER);
+    const total = parseTotalTokenPulledFromUser(slice2!, ROUTER, TOKEN);
     expect(sent?.eq(BigNumber.from('500000'))).toBe(true);
     expect(total?.eq(BigNumber.from('500025'))).toBe(true);
   });
@@ -207,7 +220,7 @@ describe('sliceLogsForMessage', () => {
     const slice1 = sliceLogsForMessage(logs, MSG_ID_1);
     expect(slice1).toHaveLength(3);
     const sent = parseSentTransferRemoteAmount(slice1!, ROUTER);
-    const total = parseTotalTokenPulledFromUser(slice1!, ROUTER, TOKEN, SENDER);
+    const total = parseTotalTokenPulledFromUser(slice1!, ROUTER, TOKEN);
     expect(sent?.eq(BigNumber.from('1000000'))).toBe(true);
     expect(total?.eq(BigNumber.from('1000050'))).toBe(true);
   });

--- a/src/features/messages/warpFees/fetchWarpFees.ts
+++ b/src/features/messages/warpFees/fetchWarpFees.ts
@@ -102,7 +102,6 @@ export async function fetchWarpFees(
         // For collateral routes the ERC20 token differs from the router;
         // for synthetic routes the router IS the ERC20 token.
         warpRouteDetails.originToken.collateralAddressOrDenom ?? routerAddress,
-        message.origin.from,
       );
   if (!totalTransferred || totalTransferred.isZero()) return null;
 
@@ -219,26 +218,25 @@ export function parseSentTransferRemoteAmount(
  *     emits `Transfer(user, 0x0, charge)`.
  *
  * Filters:
- *   - `from == senderAddress`: excludes mints (0x0 → …) and intra-router
- *     transfers (router → vault → …) that would otherwise inflate the total.
- *     Essential for lockbox / xERC20-VS / yield-vault routes where the tx
- *     contains mints of wrapper tokens to the router.
+ *   - `from != 0x0`: excludes mints. Lockbox / xERC20-VS / yield-vault routes
+ *     mint wrapper tokens to the router — those are router-side accounting,
+ *     not user pulls.
  *   - `to == router || to == 0x0`: accepts both pull patterns in one pass;
- *     the fee-recipient leg (`router → feeRecipient`) is excluded by
- *     the `from == user` gate.
+ *     the fee-recipient leg (`router → feeRecipient` / `0x0 → feeRecipient`)
+ *     is excluded because `to` is the fee recipient, not router/0x0.
  *
- * Limitation: smart-contract wallets / paymasters where `tx.from` isn't the
- * ERC20 sender will return `null` here. Correctness wins over coverage.
+ * No sender filter: per-message log slicing already scopes events to a single
+ * transferRemote call, so any qualifying Transfer inside the slice was pulled
+ * for this send. This also supports aggregator / smart-wallet senders where
+ * `tx.from` isn't the ERC20 sender.
  */
 export function parseTotalTokenPulledFromUser(
   logs: Array<RawLog>,
   routerAddress: string,
   tokenAddress: string,
-  senderAddress: string,
 ): BigNumber | null {
   const lowerRouter = routerAddress.toLowerCase();
   const lowerToken = tokenAddress.toLowerCase();
-  const lowerSender = senderAddress.toLowerCase();
 
   let total = BigNumber.from(0);
   let found = false;
@@ -250,7 +248,7 @@ export function parseTotalTokenPulledFromUser(
       if (parsed.name !== 'Transfer') continue;
       const from = (parsed.args.from as string).toLowerCase();
       const to = (parsed.args.to as string).toLowerCase();
-      if (from !== lowerSender) continue;
+      if (from === constants.AddressZero) continue; // exclude mints
       const isCollateralPull = to === lowerRouter;
       const isBurn = to === constants.AddressZero;
       if (!isCollateralPull && !isBurn) continue;


### PR DESCRIPTION
## Summary

The per-message fee parser in `fetchWarpFees` currently requires the ERC20 `Transfer` / burn to have `from == tx.from`. That gate drops any tx that routes through an aggregator, vault manager, or smart-contract wallet — the pull is emitted with the intermediary's address, not the user's EOA — so the UI shows no fee breakdown for those messages.

## Fix

Replace `from == tx.from` with `from != 0x0`. Per-message log slicing (via the `Mailbox.DispatchId` boundary) already scopes events to a single `transferRemote` call, so anything inside the slice that's a burn-from-non-zero or transfer-to-router is a pull for this message.

| Filter | Behavior |
|---|---|
| `from != 0x0` | Excludes wrapper-mint-to-router (xERC20-VS / lockbox) — this was the case the sender filter was originally added for. |
| `to == router \|\| to == 0x0` | Accepts both collateral pulls and synthetic burns in one pass. Fee-recipient transfers (`router → feeRecipient`) are naturally excluded since `to` is neither router nor `0x0`. |

Also drops the now-unused `senderAddress` param from `parseTotalTokenPulledFromUser`.

## Case that prompted the fix

Eniac msgId `0xdd74ad657d038227...` routed through aggregator `0x09dfe78aC45...`:
- Log 7 (burn): `Transfer(0xe6c08a → 0x0, 751748260)` on synthetic router `0x545E289B`
- Old filter: `from=0xe6c08a != tx.from=0x0ac55340` → dropped → no fee shown
- New filter: `from != 0x0` → counted → fee displayed

## Regression coverage

Verified against all previously-passing cases:

| Scenario | Previous | Now |
|---|---|---|
| BSC USDT collateral (direct) | ✅ | ✅ |
| Eniac synthetic burn (direct) | ✅ | ✅ |
| Eth→Igra xERC20-VS (wrapper mint 0x0→router) | ✅ excluded | ✅ still excluded |
| Base native ETH | ✅ | ✅ (native path unchanged) |
| **Eniac via aggregator** | ❌ dropped | ✅ detected |

## Changes

- `src/features/messages/warpFees/fetchWarpFees.ts` — swap sender filter for `from != 0x0`, drop `senderAddress` param + call site.
- `src/features/messages/warpFees/fetchWarpFees.test.ts` — replace the "ignores different-sender" test with two positive tests (aggregator collateral pull, intermediary synthetic burn); update docstrings + helper signatures.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run format` — clean
- [x] `pnpm run test src/features/messages/warpFees` — 22/22 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)