### PR TITLE
fix(tron): match warp-route entries via canonical bytes32

### DIFF
--- a/src/features/messages/utils.test.ts
+++ b/src/features/messages/utils.test.ts
@@ -1,7 +1,12 @@
 import { type ChainMetadata, TokenStandard } from '@hyperlane-xyz/sdk';
 import type { ChainMetadataResolver } from '@hyperlane-xyz/sdk/metadata/ChainMetadataResolver';
 import type { WarpRouteChainAddressMap } from '@hyperlane-xyz/sdk/warp/read';
-import { addressToBytes32, ProtocolType } from '@hyperlane-xyz/utils';
+import {
+  addressToBytes32,
+  bytesToProtocolAddress,
+  fromHexString,
+  ProtocolType,
+} from '@hyperlane-xyz/utils';
 
 import { MessageStatus, type MessageStub } from '../../types';
 import { parseWarpRouteMessageDetails } from './utils';
@@ -183,16 +188,20 @@ describe('parseWarpRouteMessageDetails', () => {
       expect(result!.destAmount).toBe('1');
     });
 
-    it('matches a Tron destination token whose registry address is base58 (T...)', () => {
-      // USDT TRC20 on Tron — registry stores the base58 form, but the wire
-      // recipient is bytes32 hex. The fix in formatAddress converts the wire
-      // recipient back to base58 so the warp route lookup can match.
-      const TRON_USDT_BASE58 = 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t';
-      const TRON_USDT_BYTES32 = addressToBytes32(TRON_USDT_BASE58, ProtocolType.Tron);
+    it('matches a Tron destination token whose registry key is EVM-shaped hex', () => {
+      // Production shape: hyperlane-registry stores Tron warp-route addresses as
+      // EVM-style hex (e.g. 0xbf80...3421ec), while postgresByteaToAddress decodes
+      // the wire recipient to Tron base58 before parseWarpRouteMessageDetails sees it.
+      const TRON_ROUTER_HEX = '0xbf8078818627110fD05827Ca0aa9E4518d3421ec';
+      const TRON_ROUTER_BYTES32 = addressToBytes32(TRON_ROUTER_HEX, ProtocolType.Ethereum);
+      const TRON_ROUTER_BASE58 = bytesToProtocolAddress(
+        fromHexString(TRON_ROUTER_BYTES32),
+        ProtocolType.Tron,
+      );
 
       const messageAmount = 10n ** 6n;
       const amountHex = messageAmount.toString(16).padStart(64, '0');
-      const recipientHex = TRON_USDT_BYTES32.slice(2);
+      const recipientHex = TRON_ROUTER_BYTES32.slice(2);
       const body = '0x' + recipientHex + amountHex;
 
       const message: MessageStub = {
@@ -201,12 +210,12 @@ describe('parseWarpRouteMessageDetails', () => {
         msgId: '0xabc',
         nonce: 1,
         sender: SENDER_BYTES32,
-        recipient: TRON_USDT_BYTES32,
+        recipient: TRON_ROUTER_BASE58,
         originChainId: 1,
         originDomainId: ORIGIN_DOMAIN,
         destinationChainId: 728126428,
         destinationDomainId: DEST_DOMAIN,
-        origin: { timestamp: 0, hash: '0x0', from: SENDER, to: TRON_USDT_BASE58 },
+        origin: { timestamp: 0, hash: '0x0', from: SENDER, to: TRON_ROUTER_BASE58 },
         body,
       };
 
@@ -223,10 +232,10 @@ describe('parseWarpRouteMessageDetails', () => {
           },
         },
         tron: {
-          [TRON_USDT_BASE58]: {
+          [TRON_ROUTER_HEX]: {
             chainName: 'tron',
             standard: TokenStandard.EvmHypSynthetic,
-            addressOrDenom: TRON_USDT_BASE58,
+            addressOrDenom: TRON_ROUTER_HEX,
             decimals: 6,
             symbol: 'USDT',
             name: 'Tether USD',
@@ -262,8 +271,9 @@ describe('parseWarpRouteMessageDetails', () => {
       );
 
       expect(result).toBeDefined();
+      expect(result!.originToken.symbol).toBe('USDT');
       expect(result!.destinationToken.symbol).toBe('USDT');
-      expect(result!.transferRecipient).toBe(TRON_USDT_BASE58);
+      expect(result!.transferRecipient).toBe(TRON_ROUTER_BASE58);
     });
 
     it('computes destAmount when only dest has scale (same decimals)', () => {

--- a/src/features/messages/utils.test.ts
+++ b/src/features/messages/utils.test.ts
@@ -1,7 +1,7 @@
 import { type ChainMetadata, TokenStandard } from '@hyperlane-xyz/sdk';
 import type { ChainMetadataResolver } from '@hyperlane-xyz/sdk/metadata/ChainMetadataResolver';
 import type { WarpRouteChainAddressMap } from '@hyperlane-xyz/sdk/warp/read';
-import { ProtocolType } from '@hyperlane-xyz/utils';
+import { addressToBytes32, ProtocolType } from '@hyperlane-xyz/utils';
 
 import { MessageStatus, type MessageStub } from '../../types';
 import { parseWarpRouteMessageDetails } from './utils';
@@ -181,6 +181,89 @@ describe('parseWarpRouteMessageDetails', () => {
       expect(result).toBeDefined();
       expect(result!.amount).toBe('1');
       expect(result!.destAmount).toBe('1');
+    });
+
+    it('matches a Tron destination token whose registry address is base58 (T...)', () => {
+      // USDT TRC20 on Tron — registry stores the base58 form, but the wire
+      // recipient is bytes32 hex. The fix in formatAddress converts the wire
+      // recipient back to base58 so the warp route lookup can match.
+      const TRON_USDT_BASE58 = 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t';
+      const TRON_USDT_BYTES32 = addressToBytes32(TRON_USDT_BASE58, ProtocolType.Tron);
+
+      const messageAmount = 10n ** 6n;
+      const amountHex = messageAmount.toString(16).padStart(64, '0');
+      const recipientHex = TRON_USDT_BYTES32.slice(2);
+      const body = '0x' + recipientHex + amountHex;
+
+      const message: MessageStub = {
+        status: MessageStatus.Delivered,
+        id: 'test-id',
+        msgId: '0xabc',
+        nonce: 1,
+        sender: SENDER_BYTES32,
+        recipient: TRON_USDT_BYTES32,
+        originChainId: 1,
+        originDomainId: ORIGIN_DOMAIN,
+        destinationChainId: 728126428,
+        destinationDomainId: DEST_DOMAIN,
+        origin: { timestamp: 0, hash: '0x0', from: SENDER, to: TRON_USDT_BASE58 },
+        body,
+      };
+
+      const warpRouteChainAddressMap: WarpRouteChainAddressMap = {
+        [ORIGIN_CHAIN]: {
+          [SENDER_BYTES32]: {
+            chainName: ORIGIN_CHAIN,
+            standard: TokenStandard.EvmHypCollateral,
+            addressOrDenom: SENDER,
+            decimals: 6,
+            symbol: 'USDT',
+            name: 'Tether USD',
+            wireDecimals: 6,
+          },
+        },
+        tron: {
+          [TRON_USDT_BASE58]: {
+            chainName: 'tron',
+            standard: TokenStandard.EvmHypSynthetic,
+            addressOrDenom: TRON_USDT_BASE58,
+            decimals: 6,
+            symbol: 'USDT',
+            name: 'Tether USD',
+            wireDecimals: 6,
+          },
+        },
+      };
+
+      const originMetadata = {
+        name: ORIGIN_CHAIN,
+        chainId: 1,
+        domainId: ORIGIN_DOMAIN,
+        protocol: ProtocolType.Ethereum,
+      } as ChainMetadata;
+      const destMetadata = {
+        name: 'tron',
+        chainId: 728126428,
+        domainId: DEST_DOMAIN,
+        protocol: ProtocolType.Tron,
+      } as ChainMetadata;
+      const chainMetadataResolver: Pick<ChainMetadataResolver, 'tryGetChainMetadata'> = {
+        tryGetChainMetadata: (chain: string | number): ChainMetadata | null => {
+          if (chain === ORIGIN_DOMAIN) return originMetadata;
+          if (chain === DEST_DOMAIN) return destMetadata;
+          return null;
+        },
+      };
+
+      const result = parseWarpRouteMessageDetails(
+        message,
+        warpRouteChainAddressMap,
+        chainMetadataResolver,
+      );
+
+      expect(result).toBeDefined();
+      expect(result!.destinationToken.symbol).toBe('USDT');
+      expect(result!.transferRecipient).toBe(TRON_USDT_BASE58);
     });
 
     it('computes destAmount when only dest has scale (same decimals)', () => {

--- a/src/features/messages/utils.test.ts
+++ b/src/features/messages/utils.test.ts
@@ -57,8 +57,8 @@ function buildTestSetup({
     body,
   };
 
-  // Token map keys use the full bytes32 format since sender/recipient in messages
-  // are bytes32 and getTokenFromWarpRouteChainAddressMap matches with endsWith
+  // Token map keys use bytes32 while messages may carry protocol-native addresses;
+  // getTokenFromWarpRouteChainAddressMap canonicalizes both before matching.
   const warpRouteChainAddressMap: WarpRouteChainAddressMap = {
     [ORIGIN_CHAIN]: {
       [SENDER_BYTES32]: {
@@ -274,6 +274,91 @@ describe('parseWarpRouteMessageDetails', () => {
       expect(result!.originToken.symbol).toBe('USDT');
       expect(result!.destinationToken.symbol).toBe('USDT');
       expect(result!.transferRecipient).toBe(TRON_ROUTER_BASE58);
+    });
+
+    it('matches a Tron origin token whose registry key is EVM-shaped hex', () => {
+      const TRON_ROUTER_HEX = '0xbf8078818627110fD05827Ca0aa9E4518d3421ec';
+      const TRON_ROUTER_BYTES32 = addressToBytes32(TRON_ROUTER_HEX, ProtocolType.Ethereum);
+      const TRON_ROUTER_BASE58 = bytesToProtocolAddress(
+        fromHexString(TRON_ROUTER_BYTES32),
+        ProtocolType.Tron,
+      );
+
+      const messageAmount = 10n ** 6n;
+      const amountHex = messageAmount.toString(16).padStart(64, '0');
+      const recipientHex = RECIPIENT_BYTES32.slice(2);
+      const body = '0x' + recipientHex + amountHex;
+
+      const message: MessageStub = {
+        status: MessageStatus.Delivered,
+        id: 'test-id',
+        msgId: '0xabc',
+        nonce: 1,
+        sender: TRON_ROUTER_BASE58,
+        recipient: RECIPIENT,
+        originChainId: 728126428,
+        originDomainId: ORIGIN_DOMAIN,
+        destinationChainId: 1,
+        destinationDomainId: DEST_DOMAIN,
+        origin: { timestamp: 0, hash: '0x0', from: TRON_ROUTER_BASE58, to: RECIPIENT },
+        body,
+      };
+
+      const warpRouteChainAddressMap: WarpRouteChainAddressMap = {
+        tron: {
+          [TRON_ROUTER_HEX]: {
+            chainName: 'tron',
+            standard: TokenStandard.EvmHypCollateral,
+            addressOrDenom: TRON_ROUTER_HEX,
+            decimals: 6,
+            symbol: 'USDT',
+            name: 'Tether USD',
+            wireDecimals: 6,
+          },
+        },
+        [DEST_CHAIN]: {
+          [RECIPIENT_BYTES32]: {
+            chainName: DEST_CHAIN,
+            standard: TokenStandard.EvmHypSynthetic,
+            addressOrDenom: RECIPIENT,
+            decimals: 6,
+            symbol: 'USDT',
+            name: 'Tether USD',
+            wireDecimals: 6,
+          },
+        },
+      };
+
+      const originMetadata = {
+        name: 'tron',
+        chainId: 728126428,
+        domainId: ORIGIN_DOMAIN,
+        protocol: ProtocolType.Tron,
+      } as ChainMetadata;
+      const destMetadata = {
+        name: DEST_CHAIN,
+        chainId: 1,
+        domainId: DEST_DOMAIN,
+        protocol: ProtocolType.Ethereum,
+      } as ChainMetadata;
+      const chainMetadataResolver: Pick<ChainMetadataResolver, 'tryGetChainMetadata'> = {
+        tryGetChainMetadata: (chain: string | number): ChainMetadata | null => {
+          if (chain === ORIGIN_DOMAIN) return originMetadata;
+          if (chain === DEST_DOMAIN) return destMetadata;
+          return null;
+        },
+      };
+
+      const result = parseWarpRouteMessageDetails(
+        message,
+        warpRouteChainAddressMap,
+        chainMetadataResolver,
+      );
+
+      expect(result).toBeDefined();
+      expect(result!.originToken.symbol).toBe('USDT');
+      expect(result!.destinationToken.symbol).toBe('USDT');
+      expect(result!.transferRecipient).toBe(RECIPIENT);
     });
 
     it('computes destAmount when only dest has scale (same decimals)', () => {

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -1,7 +1,10 @@
 import type { ChainMetadataResolver } from '@hyperlane-xyz/sdk/metadata/ChainMetadataResolver';
 import {
+  bytesToProtocolAddress,
+  fromHexString,
   hexToBech32mPrefix,
   hexToRadixCustomPrefix,
+  isAddressTron,
   isZeroishAddress,
   ProtocolType,
   strip0x,
@@ -19,6 +22,11 @@ export function formatAddress(
   switch (metadata?.protocol) {
     case ProtocolType.Radix:
       return hexToRadixCustomPrefix(address, 'component', metadata?.bech32Prefix, 30);
+    case ProtocolType.Tron:
+      // Wire format is bytes32 hex; registry stores Tron token addresses as base58.
+      // Convert so warp route lookups (endsWith match) and UI both use base58.
+      if (isAddressTron(address)) return address;
+      return bytesToProtocolAddress(fromHexString(address), ProtocolType.Tron);
     default:
       return address;
   }

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -1,10 +1,7 @@
 import type { ChainMetadataResolver } from '@hyperlane-xyz/sdk/metadata/ChainMetadataResolver';
 import {
-  bytesToProtocolAddress,
-  fromHexString,
   hexToBech32mPrefix,
   hexToRadixCustomPrefix,
-  isAddressTron,
   isZeroishAddress,
   ProtocolType,
   strip0x,
@@ -22,11 +19,6 @@ export function formatAddress(
   switch (metadata?.protocol) {
     case ProtocolType.Radix:
       return hexToRadixCustomPrefix(address, 'component', metadata?.bech32Prefix, 30);
-    case ProtocolType.Tron:
-      // Wire format is bytes32 hex; registry stores Tron token addresses as base58.
-      // Convert so warp route lookups (endsWith match) and UI both use base58.
-      if (isAddressTron(address)) return address;
-      return bytesToProtocolAddress(fromHexString(address), ProtocolType.Tron);
     default:
       return address;
   }

--- a/src/utils/token.test.ts
+++ b/src/utils/token.test.ts
@@ -38,7 +38,8 @@ describe('getTokenFromWarpRouteChainAddressMap', () => {
   });
 
   it('keeps suffix fallback for non-address denom keys', () => {
-    const denom = 'factory/neutron1dvzvf870mx9uf65uqhx40yzx9gu4xlqqq2pnx362a0ndmustww3smumrf5/eclip';
+    const denom =
+      'factory/neutron1dvzvf870mx9uf65uqhx40yzx9gu4xlqqq2pnx362a0ndmustww3smumrf5/eclip';
     const metadata = {
       name: 'neutron',
       protocol: ProtocolType.Cosmos,

--- a/src/utils/token.test.ts
+++ b/src/utils/token.test.ts
@@ -1,0 +1,60 @@
+import { TokenStandard, type ChainMetadata } from '@hyperlane-xyz/sdk';
+import type { WarpRouteChainAddressMap } from '@hyperlane-xyz/sdk/warp/read';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { getTokenFromWarpRouteChainAddressMap } from './token';
+
+const buildToken = (chainName: string, addressOrDenom: string, symbol = 'TOKEN') => ({
+  chainName,
+  standard: TokenStandard.EvmHypSynthetic,
+  addressOrDenom,
+  decimals: 18,
+  symbol,
+  name: symbol,
+  wireDecimals: 18,
+});
+
+describe('getTokenFromWarpRouteChainAddressMap', () => {
+  it('matches EVM addresses regardless of checksum casing', () => {
+    const checksumAddress = '0x647C621CEb36853Ef6A907E397Adf18568E70543';
+    const lowerAddress = checksumAddress.toLowerCase();
+    const metadata = {
+      name: 'ethereum',
+      protocol: ProtocolType.Ethereum,
+    } as ChainMetadata;
+    const warpRouteChainAddressMap: WarpRouteChainAddressMap = {
+      ethereum: {
+        [checksumAddress]: buildToken('ethereum', checksumAddress, 'USDT'),
+      },
+    };
+
+    const result = getTokenFromWarpRouteChainAddressMap(
+      metadata,
+      lowerAddress,
+      warpRouteChainAddressMap,
+    );
+
+    expect(result?.symbol).toBe('USDT');
+  });
+
+  it('keeps suffix fallback for non-address denom keys', () => {
+    const denom = 'factory/neutron1dvzvf870mx9uf65uqhx40yzx9gu4xlqqq2pnx362a0ndmustww3smumrf5/eclip';
+    const metadata = {
+      name: 'neutron',
+      protocol: ProtocolType.Cosmos,
+    } as ChainMetadata;
+    const warpRouteChainAddressMap: WarpRouteChainAddressMap = {
+      neutron: {
+        [denom]: buildToken('neutron', denom, 'ECLIP'),
+      },
+    };
+
+    const result = getTokenFromWarpRouteChainAddressMap(
+      metadata,
+      'eclip',
+      warpRouteChainAddressMap,
+    );
+
+    expect(result?.symbol).toBe('ECLIP');
+  });
+});

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,20 +1,40 @@
 import type { ChainMetadata } from '@hyperlane-xyz/sdk';
 import type { WarpRouteChainAddressMap } from '@hyperlane-xyz/sdk/warp/read';
-import { objKeys } from '@hyperlane-xyz/utils';
+import { addressToBytes32, isAddressEvm, objKeys, ProtocolType } from '@hyperlane-xyz/utils';
+
+// Normalize an address to lowercase bytes32 hex so registry keys and
+// resolved message addresses can be compared regardless of source form.
+// Tron warp routes are stored in the registry as EVM-shaped hex (`0x...`);
+// recipients reaching this code have already been decoded to protocol-native
+// form (e.g. base58 for Tron). Both decode to the same 20-byte payload.
+function tryToCanonicalBytes32(address: string, protocol: ProtocolType): string | undefined {
+  try {
+    const sourceProtocol = isAddressEvm(address) ? ProtocolType.Ethereum : protocol;
+    return addressToBytes32(address, sourceProtocol).toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
 
 export function getTokenFromWarpRouteChainAddressMap(
   chainMetadata: ChainMetadata,
   address: Address,
   warpRouteChainAddressMap: WarpRouteChainAddressMap,
 ) {
-  const { name } = chainMetadata;
-  if (objKeys(warpRouteChainAddressMap).includes(name)) {
-    const chain = warpRouteChainAddressMap[name];
-    for (const tokenAddress of objKeys(chain)) {
-      // There are cases where the chain record has some prefix to the token address, so we only check if the token address ends with the address we're looking for
-      if (tokenAddress.endsWith(address)) {
-        return chain[tokenAddress];
-      }
+  const { name, protocol } = chainMetadata;
+  const chain = warpRouteChainAddressMap[name];
+  if (!chain) return undefined;
+
+  const normalizedAddress = tryToCanonicalBytes32(address, protocol);
+
+  for (const tokenAddress of objKeys(chain)) {
+    const normalizedKey = tryToCanonicalBytes32(tokenAddress, protocol);
+    if (normalizedAddress && normalizedKey && normalizedAddress === normalizedKey) {
+      return chain[tokenAddress];
+    }
+    // Fallback for non-address denoms (e.g. IBC denoms) that can't be canonicalized.
+    if (!normalizedKey && tokenAddress.endsWith(address)) {
+      return chain[tokenAddress];
     }
   }
 

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -7,7 +7,10 @@ import { addressToBytes32, isAddressEvm, objKeys, ProtocolType } from '@hyperlan
 // Tron warp routes are stored in the registry as EVM-shaped hex (`0x...`);
 // recipients reaching this code have already been decoded to protocol-native
 // form (e.g. base58 for Tron). Both decode to the same 20-byte payload.
-function toCanonicalBytes32OrUndefined(address: string, protocol: ProtocolType): string | undefined {
+function toCanonicalBytes32OrUndefined(
+  address: string,
+  protocol: ProtocolType,
+): string | undefined {
   try {
     // Shape-based: 20-byte hex is decoded as EVM even on non-EVM chains
     // because some registry entries, notably Tron, are stored in that form.

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -7,8 +7,10 @@ import { addressToBytes32, isAddressEvm, objKeys, ProtocolType } from '@hyperlan
 // Tron warp routes are stored in the registry as EVM-shaped hex (`0x...`);
 // recipients reaching this code have already been decoded to protocol-native
 // form (e.g. base58 for Tron). Both decode to the same 20-byte payload.
-function tryToCanonicalBytes32(address: string, protocol: ProtocolType): string | undefined {
+function toCanonicalBytes32OrUndefined(address: string, protocol: ProtocolType): string | undefined {
   try {
+    // Shape-based: 20-byte hex is decoded as EVM even on non-EVM chains
+    // because some registry entries, notably Tron, are stored in that form.
     const sourceProtocol = isAddressEvm(address) ? ProtocolType.Ethereum : protocol;
     return addressToBytes32(address, sourceProtocol).toLowerCase();
   } catch {
@@ -25,14 +27,15 @@ export function getTokenFromWarpRouteChainAddressMap(
   const chain = warpRouteChainAddressMap[name];
   if (!chain) return undefined;
 
-  const normalizedAddress = tryToCanonicalBytes32(address, protocol);
+  const normalizedAddress = toCanonicalBytes32OrUndefined(address, protocol);
 
   for (const tokenAddress of objKeys(chain)) {
-    const normalizedKey = tryToCanonicalBytes32(tokenAddress, protocol);
+    const normalizedKey = toCanonicalBytes32OrUndefined(tokenAddress, protocol);
     if (normalizedAddress && normalizedKey && normalizedAddress === normalizedKey) {
       return chain[tokenAddress];
     }
     // Fallback for non-address denoms (e.g. IBC denoms) that can't be canonicalized.
+    // If the registry key is a valid address but lookup input is malformed, do not match.
     if (!normalizedKey && tokenAddress.endsWith(address)) {
       return chain[tokenAddress];
     }


### PR DESCRIPTION
## Summary

Tron-destination rows on the explorer message list (e.g. `?destination=tron`) silently dropped the warp transfer label (USDT amount + symbol). Tron messages still appeared, but without the token icon/amount cell.

### Root cause

`getTokenFromWarpRouteChainAddressMap` (`src/utils/token.ts`) compared the resolved recipient against registry keys via `tokenAddress.endsWith(address)`. The two sides are in different encodings for Tron:

- **Registry keys**: hyperlane-registry stores Tron warp-route entries as EVM-shaped hex (e.g. `0xbf8078818627110fD05827Ca0aa9E4518d3421ec` — verified in `deployments/warp_routes/USDT/eclipsemainnet-config.yaml` under `chainName: tron`). The SDK's `buildWarpRouteMaps` keys the per-chain map by `addressOrDenom` literally.
- **Resolved recipient**: by the time `parseWarpRouteMessageDetails` runs, `postgresByteaToAddress` (`src/features/messages/queries/encoding.ts`) has already decoded the wire bytes to **Tron base58** using the destination chain's metadata.

`endsWith` of a hex registry key against a base58 recipient never matches → `parseWarpRouteMessageDetails` returns `undefined` → `MessageTable` skips the warp cell.

### Note on the previous commit

The previous attempt (bcc534d) added a Tron branch to `formatAddress` that converted `bytes32 → base58`. In production this branch was a no-op: recipients reaching `formatAddress` had already been decoded to base58, so the new branch hit `isAddressTron(address) → true` and short-circuited. The registry-vs-recipient mismatch was unchanged.

That commit is reverted in this PR; the proper fix lives in the comparison logic itself.

## Fix

Replace the `endsWith` match in `getTokenFromWarpRouteChainAddressMap` with a canonical-form comparison:

- Normalize each side to lowercase bytes32 hex via `addressToBytes32`.
- Route EVM-shaped hex through the EVM decoder (handles both genuine EVM addresses and Tron entries the registry stores in hex form).
- Route base58 / bech32 / etc. through the chain's protocol decoder.
- Fall back to legacy `endsWith` only when a registry key can't be canonicalized (e.g. IBC denoms).

Both forms of the same Tron address resolve to the same 20-byte payload → match.

Example transfer that should now display USDT in the list: https://explorer.hyperlane.xyz/message/0xd29637bc06874c59c6af1a786dbca307d38d43475f482d312a5bb6c38951c05c

### Out of scope (separate Tron gaps, not in this PR)

- `useCollateralStatus.ts` and `useWarpRouteBalances.ts` are still gated on `ProtocolType.Ethereum` only (no balance/collateral panels on Tron destination message detail pages). Worth a follow-up.

## Test plan

- [x] `pnpm run test -- src/features/messages/utils.test.ts` — 6/6 pass. The Tron regression test now mirrors production shape: hex registry key (`0xbf80…3421ec`) + base58 recipient.
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm run lint` — clean.
- [ ] Manual: visit `/?destination=tron` against the live Hasura endpoint and confirm the USDT amount cell renders for known Tron transfers.
- [ ] Manual: open a Tron-destination message detail page and confirm the recipient field shows the `T…` base58 form.

> Note: 8 pre-existing PI-chain network test failures are unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core token lookup logic used to label warp transfers, so regressions could cause missing/incorrect token matches across chains or denom formats despite a conservative fallback.
> 
> **Overview**
> Fixes warp-route token resolution by replacing the previous `endsWith`-based match with a canonical comparison that normalizes both registry keys and message addresses to lowercase `bytes32` (treating EVM-shaped hex as Ethereum even on non-EVM chains, e.g. Tron).
> 
> Adds targeted tests covering Tron hex-registry-key vs base58-recipient matching (origin and destination) and ensures behavior remains correct for checksum-cased EVM addresses and non-address denom keys via a suffix fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90da4716e8bc75b39b9cc02d15da094256cb1654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->