### PR TITLE
fix(tron): correct Tronscan link routing and tx hash format

### DIFF
--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -40,6 +40,8 @@ export function formatTxHash(
       return strip0x(hash);
     case ProtocolType.CosmosNative:
       return strip0x(hash);
+    case ProtocolType.Tron:
+      return strip0x(hash);
     case ProtocolType.Aleo:
       return hexToBech32mPrefix(hash, 'at');
     default:

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -29,6 +29,22 @@ const validMetadata: ChainMetadata = {
   ],
 };
 
+const tronMetadata: ChainMetadata = {
+  ...validMetadata,
+  name: 'tron',
+  protocol: ProtocolType.Tron,
+  blockExplorers: [
+    {
+      name: 'Tronscan',
+      url: 'https://tronscan.org/#',
+      apiUrl: 'https://tronscan.org/#',
+      family: 'tronscan' as NonNullable<
+        NonNullable<ChainMetadata['blockExplorers']>[number]['family']
+      >,
+    },
+  ],
+};
+
 const malformedExplorerMetadata: ChainMetadata = {
   ...validMetadata,
   name: 'broken',
@@ -71,6 +87,22 @@ describe('url utils', () => {
     await expect(tryGetBlockExplorerAddressUrl(resolver, 'ethereum', '0xabc')).resolves.toBe(
       'https://etherscan.io/address/0xabc',
     );
+  });
+
+  it('routes Tronscan urls inside the SPA hash fragment', () => {
+    const resolver = createResolver(tronMetadata);
+
+    expect(getBlockExplorerTxUrl(resolver, 'tron', 'abc123')).toBe(
+      'https://tronscan.org/#/transaction/abc123',
+    );
+    expect(getBlockExplorerAddressUrl(resolver, 'tron', 'TLckRZh8CmnVe9Nqe77ESz87Pp6tXWv5Hi')).toBe(
+      'https://tronscan.org/#/address/TLckRZh8CmnVe9Nqe77ESz87Pp6tXWv5Hi',
+    );
+    // Hex-form Tron registry addresses (e.g. warp route addressOrDenom) are
+    // converted to base58 so Tronscan can resolve them.
+    expect(
+      getBlockExplorerAddressUrl(resolver, 'tron', '0xbf8078818627110fD05827Ca0aa9E4518d3421ec'),
+    ).toMatch(/^https:\/\/tronscan\.org\/#\/address\/T[1-9A-HJ-NP-Za-km-z]{33}$/);
   });
 
   it('returns null instead of throwing for malformed explorer metadata', async () => {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,6 +1,6 @@
 import type { ChainMetadata, ChainNameOrId } from '@hyperlane-xyz/sdk';
 import type { ChainMetadataResolver } from '@hyperlane-xyz/sdk/metadata/ChainMetadataResolver';
-import { isZeroishAddress } from '@hyperlane-xyz/utils';
+import { convertToProtocolAddress, isZeroishAddress, ProtocolType } from '@hyperlane-xyz/utils';
 
 import { logger } from './logger';
 
@@ -16,7 +16,7 @@ export function getBlockExplorerTxUrl(
   const baseUrl = getExplorerBaseUrl(metadata);
   if (!baseUrl) return null;
 
-  const urlPathStub = isLegacyTransactionPath(metadata.name) ? 'transaction' : 'tx';
+  const urlPathStub = isLegacyTransactionPath(metadata) ? 'transaction' : 'tx';
   return appendToPath(baseUrl, `${urlPathStub}/${hash}`)?.toString() || null;
 }
 
@@ -31,10 +31,22 @@ export function getBlockExplorerAddressUrl(
   if (!metadata) return null;
 
   const baseUrl = getExplorerBaseUrl(metadata);
-  const urlPathStub = getExplorerAddressPathStub(metadata, address);
+  const linkAddress = toExplorerAddress(metadata, address);
+  const urlPathStub = getExplorerAddressPathStub(metadata, linkAddress);
   if (!baseUrl || !urlPathStub) return null;
 
-  return appendToPath(baseUrl, `${urlPathStub}/${address}`)?.toString() || null;
+  return appendToPath(baseUrl, `${urlPathStub}/${linkAddress}`)?.toString() || null;
+}
+
+// Tron warp-route entries are stored in the registry as EVM-shaped hex
+// (`0x...`); Tronscan needs the base58 form (`T...`). Convert before linking.
+function toExplorerAddress(metadata: ChainMetadata, address: string): string {
+  if (metadata.protocol !== ProtocolType.Tron) return address;
+  try {
+    return convertToProtocolAddress(address, ProtocolType.Tron);
+  } catch {
+    return address;
+  }
 }
 
 export function tryGetBlockExplorerAddressUrl(
@@ -58,6 +70,16 @@ function getExplorerBaseUrl(metadata: ChainMetadata, index = 0) {
 
 function appendToPath(baseUrl: string, pathExtension: string) {
   try {
+    // SPA hash routing (e.g. Tronscan: `https://tronscan.org/#/transaction/<hash>`).
+    // `new URL` parses `#` as the fragment delimiter, so we'd otherwise drop the path
+    // into the URL path instead of into the hash where Tronscan's router reads it.
+    const hashIdx = baseUrl.indexOf('#');
+    if (hashIdx !== -1) {
+      const origin = baseUrl.slice(0, hashIdx);
+      const hashContent = baseUrl.slice(hashIdx + 1).replace(/\/$/, '');
+      return new URL(`${origin}#${hashContent}/${pathExtension}`);
+    }
+
     const base = new URL(baseUrl);
     let currentPath = base.pathname;
     if (currentPath.endsWith('/')) currentPath = currentPath.slice(0, -1);
@@ -79,8 +101,9 @@ function getExplorerAddressPathStub(metadata: ChainMetadata, address: string) {
   return family === 'voyager' ? 'contract' : 'address';
 }
 
-function isLegacyTransactionPath(chainName: string) {
+function isLegacyTransactionPath(metadata: ChainMetadata) {
+  if (metadata.blockExplorers?.[0]?.family === 'tronscan') return true;
   return ['nautilus', 'proteustestnet', 'radix', 'radixtestnet', 'aleo', 'aleotestnet'].includes(
-    chainName,
+    metadata.name,
   );
 }


### PR DESCRIPTION
## Summary

Tron explorer links on the explorer were either broken or pointing at non-existent Tronscan routes:

- Tx links rendered as `https://tronscan.org/tx/0x<hash>` — Tronscan's SPA needs `https://tronscan.org/#/transaction/<hash>` and strips the `0x` prefix.
- Warp transfer card token links used the registry's hex `0x...` form for Tron `addressOrDenom`, but Tronscan only resolves base58 (`T...`).

### Root cause

- `appendToPath` parses the explorer base URL through `new URL(...)`, which treats `#` as the fragment delimiter. Path segments were being appended to the URL pathname, but Tronscan's hash-router reads them from the hash fragment.
- `isLegacyTransactionPath` only enumerated specific chain names and didn't include Tron, so the path stub stayed `tx` instead of `transaction`.
- `formatTxHash` had no Tron case, so the `0x` prefix leaked into both the displayed hash and the URL.
- `getBlockExplorerAddressUrl` linked the raw `addressOrDenom` for Tron token addresses (hex `0xbf80...`), but Tronscan only resolves base58.

## Fix

- `appendToPath`: when the base URL contains `#`, insert the path inside the hash fragment so it lands where Tronscan's router reads it.
- `isLegacyTransactionPath`: detect family `tronscan` → use `transaction` instead of `tx` (works for both `tron` and `tronshasta`).
- `formatTxHash`: add `ProtocolType.Tron` case to strip `0x`, mirroring the existing Cosmos branch and Tronscan's display convention.
- `getBlockExplorerAddressUrl`: for Tron-protocol chains, route any input address through `convertToProtocolAddress(_, Tron)` so registry hex (`0xbf80…`) and already-base58 (`T…`) both yield a working Tronscan link.

Result for a known Tron USDT route:
- Before: `https://tronscan.org/tx/0xdee6ff…57f7d33`, `https://tronscan.org/address/0xbf80…3421ec`
- After: `https://tronscan.org/#/transaction/dee6ff…57f7d33`, `https://tronscan.org/#/address/T…`

## Test plan

- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` clean
- [x] `pnpm run format` clean
- [x] `pnpm exec jest src/utils/url.test.ts` — 3/3 pass; new test pins the SPA-hash and base58-conversion shapes
- [x] Manual: open a Tron-destination message detail page, verify Tx link, From link, and warp transfer Origin/Destination Token links all open the correct Tronscan page

🤖 Generated with [Claude Code](https://claude.com/claude-code)