### PR TITLE
fix(deliveryStatus): recover destination tx details when scraper lags

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/src/features/deliveryStatus/fetchDeliveryStatus.ts
+++ b/src/features/deliveryStatus/fetchDeliveryStatus.ts
@@ -91,7 +91,7 @@ async function fetchTransactionDetails(
   txHash?: string,
   blockNumber?: number,
 ) {
-  if (!txHash && !blockNumber) return { tx: null, blockTimestamp: undefined };
+  if (!txHash && !blockNumber) return { tx: null, blockTimestamp: null };
   logger.debug(`Searching for transaction details for ${txHash ?? `block ${blockNumber}`}`);
   const provider = multiProvider.getEthersV5Provider(domainId);
   const [tx, block] = await Promise.all([
@@ -108,5 +108,5 @@ async function fetchTransactionDetails(
         })
       : Promise.resolve(null),
   ]);
-  return { tx, blockTimestamp: block?.timestamp };
+  return { tx, blockTimestamp: block?.timestamp ?? null };
 }

--- a/src/features/deliveryStatus/fetchDeliveryStatus.ts
+++ b/src/features/deliveryStatus/fetchDeliveryStatus.ts
@@ -43,16 +43,17 @@ export async function fetchDeliveryStatus(
   );
 
   if (isDelivered) {
-    const txDetails = await fetchTransactionDetails(
+    const { tx: txDetails, blockTimestamp } = await fetchTransactionDetails(
       multiProvider,
       message.destinationDomainId,
       transactionHash,
+      blockNumber,
     );
     // If a delivery (aka process) tx is found, mark as success
     const result: MessageDeliverySuccessResult = {
       status: MessageStatus.Delivered,
       deliveryTransaction: {
-        timestamp: toDecimalNumber(txDetails?.timestamp || 0) * 1000,
+        timestamp: toDecimalNumber(blockTimestamp ?? txDetails?.timestamp ?? 0) * 1000,
         hash: transactionHash || constants.HashZero,
         from: txDetails?.from || constants.AddressZero,
         to: txDetails?.to || constants.AddressZero,
@@ -84,13 +85,18 @@ export async function fetchDeliveryStatus(
   }
 }
 
-function fetchTransactionDetails(
+async function fetchTransactionDetails(
   multiProvider: MultiProtocolProvider,
   domainId: DomainId,
   txHash?: string,
+  blockNumber?: number,
 ) {
-  if (!txHash) return null;
+  if (!txHash) return { tx: null, blockTimestamp: undefined };
   logger.debug(`Searching for transaction details for ${txHash}`);
   const provider = multiProvider.getEthersV5Provider(domainId);
-  return provider.getTransaction(txHash);
+  const [tx, block] = await Promise.all([
+    provider.getTransaction(txHash),
+    blockNumber ? provider.getBlock(blockNumber).catch(() => null) : Promise.resolve(null),
+  ]);
+  return { tx, blockTimestamp: block?.timestamp };
 }

--- a/src/features/deliveryStatus/fetchDeliveryStatus.ts
+++ b/src/features/deliveryStatus/fetchDeliveryStatus.ts
@@ -53,7 +53,7 @@ export async function fetchDeliveryStatus(
     const result: MessageDeliverySuccessResult = {
       status: MessageStatus.Delivered,
       deliveryTransaction: {
-        timestamp: toDecimalNumber(blockTimestamp ?? txDetails?.timestamp ?? 0) * 1000,
+        timestamp: toDecimalNumber(blockTimestamp ?? 0) * 1000,
         hash: transactionHash || constants.HashZero,
         from: txDetails?.from || constants.AddressZero,
         to: txDetails?.to || constants.AddressZero,
@@ -91,12 +91,22 @@ async function fetchTransactionDetails(
   txHash?: string,
   blockNumber?: number,
 ) {
-  if (!txHash) return { tx: null, blockTimestamp: undefined };
-  logger.debug(`Searching for transaction details for ${txHash}`);
+  if (!txHash && !blockNumber) return { tx: null, blockTimestamp: undefined };
+  logger.debug(`Searching for transaction details for ${txHash ?? `block ${blockNumber}`}`);
   const provider = multiProvider.getEthersV5Provider(domainId);
   const [tx, block] = await Promise.all([
-    provider.getTransaction(txHash),
-    blockNumber ? provider.getBlock(blockNumber).catch(() => null) : Promise.resolve(null),
+    txHash ? provider.getTransaction(txHash) : Promise.resolve(null),
+    blockNumber
+      ? provider.getBlock(blockNumber).catch((error) => {
+          logger.warn('Failed to fetch block for delivery timestamp', {
+            domainId,
+            txHash,
+            blockNumber,
+            error,
+          });
+          return null;
+        })
+      : Promise.resolve(null),
   ]);
   return { tx, blockTimestamp: block?.timestamp };
 }

--- a/src/features/messages/deliveryUtils.ts
+++ b/src/features/messages/deliveryUtils.ts
@@ -143,8 +143,13 @@ export async function checkIsMessageDelivered(
     }
     return { isDelivered: false };
   } catch (error) {
-    // Pre-v3 mailboxes don't expose processedAt; fall back to the boolean.
-    logger.warn(`Error calling processedAt for msgId ${msgId}, falling back to delivered()`, error);
+    // processedAt may revert on pre-v3 mailboxes that don't expose it, or on
+    // transient RPC issues. Either way, fall back to the boolean so we don't
+    // block the UI; tx-hash recovery is lost in this branch.
+    logger.warn(
+      `processedAt call failed for msgId ${msgId} (pre-v3 mailbox or RPC issue); falling back to delivered()`,
+      error,
+    );
     try {
       const isDelivered = await mailbox.delivered(msgId);
       return { isDelivered };

--- a/src/features/messages/deliveryUtils.ts
+++ b/src/features/messages/deliveryUtils.ts
@@ -74,8 +74,10 @@ export async function extractMessageIdFromTx(
 
 /**
  * Checks if a Hyperlane message has been delivered on the destination chain.
- * Queries for ProcessId events on the destination mailbox, with a fallback to
- * calling the mailbox.delivered() method if logs are unreliable.
+ * Tries ProcessId logs in a recent block window first; on miss, uses
+ * mailbox.processedAt() to locate the exact delivery block and fetch the log
+ * there so the caller still gets a tx hash. Falls back to mailbox.delivered()
+ * for pre-v3 mailboxes that don't expose processedAt.
  */
 export async function checkIsMessageDelivered(
   msgId: string,
@@ -116,12 +118,39 @@ export async function checkIsMessageDelivered(
   }
 
   try {
-    logger.debug(`Querying mailbox about msgId ${msgId}`);
-    const isDelivered = await mailbox.delivered(msgId);
-    logger.debug(`Mailbox delivery status for ${msgId}: ${isDelivered}`);
-    return { isDelivered };
-  } catch (error) {
-    logger.warn(`Error checking delivered status for msgId ${msgId}`, error);
+    logger.debug(`Querying mailbox.processedAt for msgId ${msgId}`);
+    const processedBlock = await mailbox.processedAt(msgId);
+    if (processedBlock > 0) {
+      try {
+        const logs = await mailbox.queryFilter(
+          mailbox.filters.ProcessId(msgId),
+          processedBlock,
+          processedBlock,
+        );
+        if (logs?.length) {
+          const log = logs[0];
+          return {
+            isDelivered: true,
+            transactionHash: log.transactionHash,
+            blockNumber: log.blockNumber,
+          };
+        }
+        logger.warn(`processedAt returned ${processedBlock} but no ProcessId log at that block`);
+      } catch (error) {
+        logger.warn(`Error querying ProcessId log at block ${processedBlock}`, error);
+      }
+      return { isDelivered: true, blockNumber: processedBlock };
+    }
     return { isDelivered: false };
+  } catch (error) {
+    // Pre-v3 mailboxes don't expose processedAt; fall back to the boolean.
+    logger.warn(`Error calling processedAt for msgId ${msgId}, falling back to delivered()`, error);
+    try {
+      const isDelivered = await mailbox.delivered(msgId);
+      return { isDelivered };
+    } catch (error2) {
+      logger.warn(`Error checking delivered status for msgId ${msgId}`, error2);
+      return { isDelivered: false };
+    }
   }
 }


### PR DESCRIPTION
## Summary

When a message has actually been delivered on-chain but the Hasura indexer hasn't recorded the destination tx yet, GraphQL returns `is_delivered: false` and all destination fields as `null`. The client-side delivery check then queries the destination mailbox directly. Previously, if the recent-block `ProcessId` log scan came up empty (delivery older than the lookback window), the fallback only called `mailbox.delivered(msgId)` — a boolean. The UI would flip status to **Delivered** while rendering zero-address placeholders for the destination tx hash, sender, recipient, and a 0 timestamp. Status said one thing, fields said another.

This PR recovers the missing data:

- **`deliveryUtils.ts`** — on log-scan miss, call `mailbox.processedAt(msgId)`. If `> 0`, run a single-block `queryFilter(ProcessId, processedBlock, processedBlock)` to retrieve the exact tx hash and block. If `processedAt` reverts (pre-v3 mailboxes that don't expose it), fall back to the original `delivered()` boolean.
- **`fetchDeliveryStatus.ts`** — `fetchTransactionDetails` now fetches the block in parallel with `getTransaction` and uses `block.timestamp`. ethers v5's `getTransaction()` does not return the block timestamp, which is why timestamp was always 0 even when the rest of the tx data populated.

Net effect: when the indexer is behind, the destination card now shows the real hash, sender, recipient, block, and timestamp instead of placeholder zeros.

## Test plan

- [x] Typecheck passes (`pnpm run typecheck`)
- [x] Lint passes (`pnpm run lint`)
- [x] Existing Jest suites pass (`pnpm run test`)
- [x] On a delivered message where the indexer has NOT yet recorded the destination tx: destination card shows real tx hash, from, to, block, timestamp (no zero-address placeholders)
- [ ] On a delivered message within the recent-block fast path: behavior unchanged
- [ ] On an undelivered (genuinely pending) message: still shows pending, no false-positive Delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)