### PR TITLE
fix(messages): tolerate all-zero address bytes when parsing message

### DIFF
--- a/src/features/messages/queries/encoding.ts
+++ b/src/features/messages/queries/encoding.ts
@@ -40,6 +40,11 @@ export function postgresByteaToAddress(
   const hexString = postgresByteaToString(byteString);
   if (!chainMetadata) return hexString;
   const addressBytes = Buffer.from(strip0x(hexString), 'hex');
+  // Scraper occasionally records all-zero bytes for tx senders/recipients on
+  // some non-EVM chains (observed on paradex mainnet). bytesToProtocolAddress
+  // asserts on empty/all-zero input, which would otherwise fail the entire
+  // message parse and surface "Message not found".
+  if (!addressBytes.length || addressBytes.every((b) => b === 0)) return hexString;
   return bytesToProtocolAddress(addressBytes, chainMetadata.protocol, chainMetadata.bech32Prefix);
 }
 


### PR DESCRIPTION
## Summary

- Short-circuit the all-zero / empty case inside `postgresByteaToAddress` and return the raw hex string, so messages with a corrupt all-zero `origin_tx_sender` / `origin_tx_recipient` still render instead of falling through to the catch-all in `parseMessage`.

## Why

The scraper currently writes 20-byte all-zero values for `origin_tx_sender` on some non-EVM chains (observed on **paradex mainnet**, e.g. `\\x0000000000000000000000000000000000000000`). `bytesToProtocolAddress` asserts on empty/all-zero input, so the whole `parseMessage` throw → `null` short-circuits and the page surfaces "Message not found" while falling back to PI search across every EVM chain.

Repro before fix: https://explorer.hyperlane.xyz/message/0x77a1f8758523f98bcc87b0f0d0ea0433dc67e790308e554c5ea45710ec45da61 (paradex → ethereum, USDC/paradex, nonce 61740). Hasura returns the row for that `msg_id` — the page only fails because the row's `origin_tx_sender` is the all-zero blob.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] Stuck paradex message above renders origin chain, tx hash, sender, body, etc. instead of "Message not found"
- [ ] Existing healthy paradex messages (e.g. `0xf07366e1fa5be451130f6a234ae7844857be19bc28783d3fe86feb1d5b2c9a23`) still render unchanged