### PR TITLE
chore: migrate to pnpm 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-pnpm-11-store-
 
       - name: Install dependencies
         run: |
@@ -65,9 +65,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-pnpm-11-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -95,9 +95,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-pnpm-11-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -131,9 +131,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-pnpm-11-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-11-store-
 
@@ -65,7 +65,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-11-store-
 
@@ -95,7 +95,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-11-store-
 
@@ -131,7 +131,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-11-store-
 

--- a/.github/workflows/update-hyperlane-deps.yml
+++ b/.github/workflows/update-hyperlane-deps.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version-file: .nvmrc
 
       - uses: pnpm/action-setup@v4
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-enable-pre-post-scripts=true

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "homepage": "https://www.hyperlane.xyz",
   "license": "Apache-2.0",
   "main": "dist/src/index.js",
-  "packageManager": "pnpm@10.25.0",
+  "packageManager": "pnpm@11.1.3",
   "private": true,
   "repository": {
     "type": "git",
@@ -76,17 +76,5 @@
     "test": "jest",
     "format": "oxfmt ./src"
   },
-  "types": "dist/src/index.d.ts",
-  "pnpm": {
-    "overrides": {
-      "tronweb>ethers": "^6.13.5",
-      "ethers": "^5.7",
-      "sha.js": "2.4.12",
-      "cipher-base": "1.0.5",
-      "elliptic": "6.6.1",
-      "pbkdf2": "3.1.3",
-      "form-data": "4.0.4"
-    },
-    "onlyBuiltDependencies": []
-  }
+  "types": "dist/src/index.d.ts"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,12 @@
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - '@hyperlane-xyz/*'
+overrides:
+  tronweb>ethers: ^6.13.5
+  ethers: ^5.7
+  sha.js: 2.4.12
+  cipher-base: 1.0.5
+  elliptic: 6.6.1
+  pbkdf2: 3.1.3
+  form-data: 4.0.4
+enablePrePostScripts: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,15 @@ overrides:
   pbkdf2: 3.1.3
   form-data: 4.0.4
 enablePrePostScripts: true
+allowBuilds:
+  '@parcel/watcher': false
+  bigint-buffer: false
+  bufferutil: false
+  core-js: false
+  esbuild: false
+  keccak: false
+  protobufjs: false
+  secp256k1: false
+  sharp: false
+  tiny-secp256k1: false
+  utf-8-validate: false


### PR DESCRIPTION
## Summary
- Bumped the repo package manager pin to pnpm 11.1.3.
- Moved pnpm overrides into `pnpm-workspace.yaml` for pnpm 11.
- Moved `enable-pre-post-scripts` out of `.npmrc` and into `pnpm-workspace.yaml`, then removed the non-auth `.npmrc`.

## Validation
- `pnpm@11.1.3 install --lockfile-only --ignore-scripts`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm install --frozen-lockfile`
- `git diff --check`