### PR TITLE
fix: show cross-collateral route balances

### DIFF
--- a/src/features/messages/cards/WarpRouteVisualizationCard.tsx
+++ b/src/features/messages/cards/WarpRouteVisualizationCard.tsx
@@ -8,7 +8,7 @@ import { Card } from '../../../components/layout/Card';
 import HubIcon from '../../../images/icons/hub.svg';
 import { useMultiProvider } from '../../../store';
 import { Message, MessageStub, WarpRouteDetails } from '../../../types';
-import { CrossCollateralEnrollments } from '../warpVisualization/CrossCollateralEnrollments';
+import { RouteEnrollments } from '../warpVisualization/RouteEnrollments';
 import { useWarpRouteBalances } from '../warpVisualization/useWarpRouteBalances';
 import { useWarpRouteVisualization } from '../warpVisualization/useWarpRouteVisualization';
 import { WarpRouteGraph } from '../warpVisualization/WarpRouteGraph';
@@ -114,7 +114,7 @@ export function WarpRouteVisualizationCard({ message, warpRouteDetails, blur }: 
             />
           </div>
 
-          <CrossCollateralEnrollments visualization={visualization} />
+          <RouteEnrollments visualization={visualization} />
 
           {/* Refresh Balances Button */}
           <div className="flex justify-center">

--- a/src/features/messages/cards/WarpRouteVisualizationCard.tsx
+++ b/src/features/messages/cards/WarpRouteVisualizationCard.tsx
@@ -8,6 +8,7 @@ import { Card } from '../../../components/layout/Card';
 import HubIcon from '../../../images/icons/hub.svg';
 import { useMultiProvider } from '../../../store';
 import { Message, MessageStub, WarpRouteDetails } from '../../../types';
+import { CrossCollateralEnrollments } from '../warpVisualization/CrossCollateralEnrollments';
 import { useWarpRouteBalances } from '../warpVisualization/useWarpRouteBalances';
 import { useWarpRouteVisualization } from '../warpVisualization/useWarpRouteVisualization';
 import { WarpRouteGraph } from '../warpVisualization/WarpRouteGraph';
@@ -28,7 +29,7 @@ export function WarpRouteVisualizationCard({ message, warpRouteDetails, blur }: 
   // Get balances with manual refetch - only fetch when expanded
   const {
     balances,
-    isLoading: isBalancesLoading,
+    isFetching: isBalancesFetching,
     refetch: refetchBalances,
   } = useWarpRouteBalances(
     visualization?.tokens,
@@ -104,12 +105,16 @@ export function WarpRouteVisualizationCard({ message, warpRouteDetails, blur }: 
               tokens={visualization.tokens}
               originChain={originChainName}
               destinationChain={destinationChainName}
+              originAddressOrDenom={warpRouteDetails.originToken.addressOrDenom}
+              destinationAddressOrDenom={warpRouteDetails.destinationToken.addressOrDenom}
               balances={balances}
               transferAmount={transferAmount}
               transferAmountDisplay={warpRouteDetails.amount}
               tokenSymbol={warpRouteDetails.originToken.symbol}
             />
           </div>
+
+          <CrossCollateralEnrollments visualization={visualization} />
 
           {/* Refresh Balances Button */}
           <div className="flex justify-center">
@@ -118,10 +123,10 @@ export function WarpRouteVisualizationCard({ message, warpRouteDetails, blur }: 
                 e.stopPropagation();
                 refetchBalances();
               }}
-              disabled={isBalancesLoading}
+              disabled={isBalancesFetching}
               className="flex items-center gap-2 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
             >
-              {isBalancesLoading ? (
+              {isBalancesFetching ? (
                 <SpinnerIcon width={16} height={16} />
               ) : (
                 <RefreshIcon width={16} height={16} />

--- a/src/features/messages/warpVisualization/CrossCollateralEnrollments.tsx
+++ b/src/features/messages/warpVisualization/CrossCollateralEnrollments.tsx
@@ -1,0 +1,114 @@
+import { shortenAddress } from '@hyperlane-xyz/utils';
+import { CopyButton } from '@hyperlane-xyz/widgets';
+
+import { ChainLogo } from '../../../components/icons/ChainLogo';
+import { useMultiProvider } from '../../../store';
+import { isCrossCollateralTokenStandard } from './tokenStandards';
+import {
+  getWarpRouteTokenKey,
+  type WarpRouteEnrollment,
+  type WarpRouteTokenVisualization,
+  type WarpRouteVisualization,
+} from './types';
+
+export function hasCrossCollateralTokens(visualization: WarpRouteVisualization): boolean {
+  return visualization.tokens.some((token) => isCrossCollateralTokenStandard(token.standard));
+}
+
+interface Props {
+  visualization: WarpRouteVisualization;
+}
+
+export function CrossCollateralEnrollments({ visualization }: Props) {
+  const multiProvider = useMultiProvider();
+
+  if (!hasCrossCollateralTokens(visualization)) return null;
+
+  return (
+    <div className="space-y-2">
+      <div className="text-xs font-medium uppercase tracking-wide text-gray-500">
+        Route enrollments
+      </div>
+      <div className="space-y-2">
+        {visualization.tokens.map((token) => (
+          <EnrollmentRow
+            key={getWarpRouteTokenKey(token)}
+            token={token}
+            multiProvider={multiProvider}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EnrollmentRow({
+  token,
+  multiProvider,
+}: {
+  token: WarpRouteTokenVisualization;
+  multiProvider: ReturnType<typeof useMultiProvider>;
+}) {
+  const displayName =
+    multiProvider.tryGetChainMetadata(token.chainName)?.displayName || token.chainName;
+
+  return (
+    <div className="rounded-md border border-gray-200 bg-white p-3 text-xs">
+      <div className="flex flex-wrap items-center gap-2">
+        <ChainLogo chainName={token.chainName} size={18} />
+        <span className="font-semibold">{displayName}</span>
+        <span className="rounded bg-gray-100 px-1.5 py-0.5 font-medium text-gray-700">
+          {token.symbol || 'Unknown'}
+        </span>
+        {token.collateralAddressOrDenom && (
+          <span className="flex items-center gap-1 text-[10px] text-gray-500">
+            collateral
+            <span className="font-mono">{shortenAddress(token.collateralAddressOrDenom)}</span>
+            <CopyButton
+              copyValue={token.collateralAddressOrDenom}
+              width={10}
+              height={10}
+              className="opacity-50"
+            />
+          </span>
+        )}
+        <span className="ml-auto text-[10px] text-gray-500">
+          {token.enrollments.length} enrollment{token.enrollments.length === 1 ? '' : 's'}
+        </span>
+      </div>
+      {token.enrollments.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {token.enrollments.map((enrollment) => (
+            <EnrollmentChip
+              key={getWarpRouteTokenKey(enrollment)}
+              enrollment={enrollment}
+              multiProvider={multiProvider}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EnrollmentChip({
+  enrollment,
+  multiProvider,
+}: {
+  enrollment: WarpRouteEnrollment;
+  multiProvider: ReturnType<typeof useMultiProvider>;
+}) {
+  const displayName =
+    multiProvider.tryGetChainMetadata(enrollment.chainName)?.displayName || enrollment.chainName;
+
+  return (
+    <span className="flex items-center gap-1 rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5">
+      <ChainLogo chainName={enrollment.chainName} size={12} />
+      <span className="font-medium">{displayName}</span>
+      {enrollment.symbol && <span className="text-gray-600">- {enrollment.symbol}</span>}
+      <span className="font-mono text-[10px] text-gray-500">
+        {shortenAddress(enrollment.addressOrDenom)}
+      </span>
+    </span>
+  );
+}

--- a/src/features/messages/warpVisualization/RouteEnrollments.tsx
+++ b/src/features/messages/warpVisualization/RouteEnrollments.tsx
@@ -3,26 +3,22 @@ import { CopyButton } from '@hyperlane-xyz/widgets';
 
 import { ChainLogo } from '../../../components/icons/ChainLogo';
 import { useMultiProvider } from '../../../store';
-import { isCrossCollateralTokenStandard } from './tokenStandards';
 import {
   getWarpRouteTokenKey,
+  hasRouteEnrollments,
   type WarpRouteEnrollment,
   type WarpRouteTokenVisualization,
   type WarpRouteVisualization,
 } from './types';
 
-export function hasCrossCollateralTokens(visualization: WarpRouteVisualization): boolean {
-  return visualization.tokens.some((token) => isCrossCollateralTokenStandard(token.standard));
-}
-
 interface Props {
   visualization: WarpRouteVisualization;
 }
 
-export function CrossCollateralEnrollments({ visualization }: Props) {
+export function RouteEnrollments({ visualization }: Props) {
   const multiProvider = useMultiProvider();
 
-  if (!hasCrossCollateralTokens(visualization)) return null;
+  if (!hasRouteEnrollments(visualization)) return null;
 
   return (
     <div className="space-y-2">

--- a/src/features/messages/warpVisualization/WarpRouteGraph.tsx
+++ b/src/features/messages/warpVisualization/WarpRouteGraph.tsx
@@ -7,13 +7,16 @@ import { ChainLogo } from '../../../components/icons/ChainLogo';
 import { useMultiProvider } from '../../../store';
 import { formatAmountCompact } from '../../../utils/amount';
 import { tryGetBlockExplorerAddressUrl } from '../../../utils/url';
-import { ChainBalance, WarpRouteTokenVisualization } from './types';
+import { normalizeAddressToHex } from '../../../utils/yamlParsing';
+import { ChainBalance, getWarpRouteTokenKey, WarpRouteTokenVisualization } from './types';
 import { isCollateralTokenStandard } from './useWarpRouteVisualization';
 
 interface WarpRouteGraphProps {
   tokens: WarpRouteTokenVisualization[];
   originChain: string;
   destinationChain: string;
+  originAddressOrDenom?: string;
+  destinationAddressOrDenom?: string;
   balances: Record<string, ChainBalance>;
   transferAmount?: bigint;
   transferAmountDisplay?: string;
@@ -56,6 +59,16 @@ function isSyntheticToken(token: WarpRouteTokenVisualization): boolean {
 
 function isXERC20Token(token: WarpRouteTokenVisualization): boolean {
   return token.standard ? token.standard.includes('XERC20') : false;
+}
+
+function tokenMatchesEndpoint(
+  token: WarpRouteTokenVisualization,
+  chainName: string,
+  addressOrDenom: string | undefined,
+): boolean {
+  if (token.chainName !== chainName) return false;
+  if (!addressOrDenom) return true;
+  return normalizeAddressToHex(token.addressOrDenom) === normalizeAddressToHex(addressOrDenom);
 }
 
 /**
@@ -101,7 +114,7 @@ function CompactChainNode({
     transferAmount !== undefined &&
     balance < transferAmount;
 
-  const explorerUrl = explorerUrls[`${token.chainName}:${token.addressOrDenom}`];
+  const explorerUrl = explorerUrls[getWarpRouteTokenKey(token)];
 
   const chainMetadata = multiProvider.tryGetChainMetadata(token.chainName);
   const displayName = chainMetadata?.displayName || token.chainName;
@@ -213,7 +226,6 @@ function MinimalChainNode({
       >
         {getTokenTypeLabel(token.standard)}
       </span>
-
       {/* Balance for collateral/synthetic (non-xERC20) */}
       {balance !== undefined && (isCollateral || isSynthetic) && !isXERC20 && (
         <div
@@ -249,6 +261,8 @@ export function WarpRouteGraph({
   tokens,
   originChain,
   destinationChain,
+  originAddressOrDenom,
+  destinationAddressOrDenom,
   balances,
   transferAmount,
   transferAmountDisplay,
@@ -264,7 +278,7 @@ export function WarpRouteGraph({
       const fetchTasks: { key: string; promise: Promise<string | null> }[] = [];
 
       for (const token of tokens) {
-        const tokenKey = `${token.chainName}:${token.addressOrDenom}`;
+        const tokenKey = getWarpRouteTokenKey(token);
         fetchTasks.push({
           key: tokenKey,
           promise: tryGetBlockExplorerAddressUrl(
@@ -290,10 +304,16 @@ export function WarpRouteGraph({
   }, [tokens, multiProvider]);
 
   // Get origin and destination tokens
-  const originToken = tokens.find((t) => t.chainName === originChain);
-  const destToken = tokens.find((t) => t.chainName === destinationChain);
+  const originToken = tokens.find((t) =>
+    tokenMatchesEndpoint(t, originChain, originAddressOrDenom),
+  );
+  const destToken = tokens.find((t) =>
+    tokenMatchesEndpoint(t, destinationChain, destinationAddressOrDenom),
+  );
+  const originTokenKey = originToken ? getWarpRouteTokenKey(originToken) : undefined;
+  const destTokenKey = destToken ? getWarpRouteTokenKey(destToken) : undefined;
   const otherTokens = tokens.filter(
-    (t) => t.chainName !== originChain && t.chainName !== destinationChain,
+    (t) => getWarpRouteTokenKey(t) !== originTokenKey && getWarpRouteTokenKey(t) !== destTokenKey,
   );
 
   if (tokens.length === 0) {
@@ -304,49 +324,51 @@ export function WarpRouteGraph({
     );
   }
 
-  const originBalance = originToken ? balances[originToken.chainName] : undefined;
-  const destBalance = destToken ? balances[destToken.chainName] : undefined;
+  const originBalance = originTokenKey ? balances[originTokenKey] : undefined;
+  const destBalance = destTokenKey ? balances[destTokenKey] : undefined;
 
   return (
     <div className="relative flex flex-col items-center gap-4 py-4">
       {/* Main transfer visualization - origin and destination */}
-      <div className="flex items-center gap-4">
-        {/* Origin */}
-        <CompactChainNode
-          token={originToken}
-          chainBalance={originBalance}
-          transferAmount={transferAmount}
-          borderColor="border-primary-500"
-          multiProvider={multiProvider}
-          explorerUrls={explorerUrls}
-        />
+      <div className="w-full overflow-x-auto pb-2">
+        <div className="flex min-w-max items-center justify-center gap-4 px-1">
+          {/* Origin */}
+          <CompactChainNode
+            token={originToken}
+            chainBalance={originBalance}
+            transferAmount={transferAmount}
+            borderColor="border-primary-500"
+            multiProvider={multiProvider}
+            explorerUrls={explorerUrls}
+          />
 
-        {/* Arrow with transfer amount */}
-        <div className="flex flex-col items-center">
-          <div className="flex items-center">
-            <div className="h-0.5 w-8 bg-primary-500" />
-            {transferAmountDisplay && tokenSymbol && (
-              <div className="rounded border border-primary-500 bg-white px-2 py-1">
-                <span className="text-xs font-medium text-primary-700">
-                  {transferAmountDisplay} {tokenSymbol}
-                </span>
-              </div>
-            )}
-            <div className="h-0.5 w-8 bg-primary-500" />
-            <div className="h-0 w-0 border-b-[6px] border-l-[8px] border-t-[6px] border-b-transparent border-l-primary-500 border-t-transparent" />
+          {/* Arrow with transfer amount */}
+          <div className="flex flex-col items-center">
+            <div className="flex items-center">
+              <div className="h-0.5 w-8 bg-primary-500" />
+              {transferAmountDisplay && tokenSymbol && (
+                <div className="rounded border border-primary-500 bg-white px-2 py-1">
+                  <span className="block max-w-[112px] truncate text-xs font-medium text-primary-700">
+                    {transferAmountDisplay} {tokenSymbol}
+                  </span>
+                </div>
+              )}
+              <div className="h-0.5 w-8 bg-primary-500" />
+              <div className="h-0 w-0 border-b-[6px] border-l-[8px] border-t-[6px] border-b-transparent border-l-primary-500 border-t-transparent" />
+            </div>
           </div>
-        </div>
 
-        {/* Destination */}
-        <CompactChainNode
-          token={destToken}
-          chainBalance={destBalance}
-          transferAmount={transferAmount}
-          borderColor="border-primary-500"
-          multiProvider={multiProvider}
-          explorerUrls={explorerUrls}
-          isDestination={true}
-        />
+          {/* Destination */}
+          <CompactChainNode
+            token={destToken}
+            chainBalance={destBalance}
+            transferAmount={transferAmount}
+            borderColor="border-primary-500"
+            multiProvider={multiProvider}
+            explorerUrls={explorerUrls}
+            isDestination={true}
+          />
+        </div>
       </div>
 
       {/* Other chains in a compact grid */}
@@ -356,9 +378,9 @@ export function WarpRouteGraph({
           <div className="flex flex-wrap justify-center gap-2">
             {otherTokens.map((token) => (
               <MinimalChainNode
-                key={token.chainName}
+                key={getWarpRouteTokenKey(token)}
                 token={token}
-                chainBalance={balances[token.chainName]}
+                chainBalance={balances[getWarpRouteTokenKey(token)]}
                 multiProvider={multiProvider}
               />
             ))}

--- a/src/features/messages/warpVisualization/tokenStandards.ts
+++ b/src/features/messages/warpVisualization/tokenStandards.ts
@@ -1,0 +1,27 @@
+import {
+  TOKEN_COLLATERALIZED_STANDARDS,
+  TOKEN_CROSS_COLLATERAL_STANDARDS,
+  TokenStandard,
+} from '@hyperlane-xyz/sdk/token/TokenStandard';
+
+export const SUPPORTED_SEALEVEL_BALANCE_STANDARDS: TokenStandard[] = [
+  TokenStandard.SealevelHypCollateral,
+  TokenStandard.SealevelHypCrossCollateral,
+  TokenStandard.SealevelHypNative,
+  TokenStandard.SealevelHypSynthetic,
+];
+
+export const COLLATERAL_TOKEN_STANDARDS: TokenStandard[] = [
+  ...TOKEN_COLLATERALIZED_STANDARDS,
+  TokenStandard.EvmHypCollateralFiat,
+  TokenStandard.CosmosIbc,
+];
+
+export const CROSS_COLLATERAL_TOKEN_STANDARDS: TokenStandard[] = Array.from(
+  TOKEN_CROSS_COLLATERAL_STANDARDS,
+);
+
+export function isCrossCollateralTokenStandard(standard: string | undefined): boolean {
+  if (!standard) return false;
+  return CROSS_COLLATERAL_TOKEN_STANDARDS.includes(standard as TokenStandard);
+}

--- a/src/features/messages/warpVisualization/types.ts
+++ b/src/features/messages/warpVisualization/types.ts
@@ -1,4 +1,11 @@
-import { TokenStandard, WarpCoreConfig } from '@hyperlane-xyz/sdk';
+import type { TokenStandard } from '@hyperlane-xyz/sdk/token/TokenStandard';
+import type { WarpCoreConfig } from '@hyperlane-xyz/sdk/warp/types';
+
+export interface WarpRouteEnrollment {
+  chainName: string;
+  addressOrDenom: string;
+  symbol: string;
+}
 
 // Token info from registry for visualization
 export interface WarpRouteTokenVisualization {
@@ -8,10 +15,18 @@ export interface WarpRouteTokenVisualization {
   symbol: string;
   decimals: number;
   standard?: TokenStandard;
+  collateralAddressOrDenom?: string;
+  enrollments: WarpRouteEnrollment[];
   logoURI?: string;
   // Balance data (fetched via adapters when expanded)
   collateralBalance?: bigint;
   isCollateralInsufficient?: boolean;
+}
+
+export function getWarpRouteTokenKey(
+  token: Pick<WarpRouteTokenVisualization, 'chainName' | 'addressOrDenom'>,
+): string {
+  return `${token.chainName}:${token.addressOrDenom}`;
 }
 
 export interface WarpRouteVisualization {
@@ -27,9 +42,10 @@ export interface ChainBalance {
 }
 
 export interface WarpRouteBalances {
-  // Map of chainName -> balance data
+  // Map of token key -> balance data
   balances: Record<string, ChainBalance>;
   isLoading: boolean;
+  isFetching: boolean;
   error?: string;
   refetch: () => void;
 }

--- a/src/features/messages/warpVisualization/types.ts
+++ b/src/features/messages/warpVisualization/types.ts
@@ -35,6 +35,10 @@ export interface WarpRouteVisualization {
   tokens: WarpRouteTokenVisualization[];
 }
 
+export function hasRouteEnrollments(visualization: WarpRouteVisualization): boolean {
+  return visualization.tokens.some((token) => token.enrollments.length > 0);
+}
+
 export interface ChainBalance {
   balance: bigint;
   xerc20Supply?: bigint; // total supply of xERC20 token

--- a/src/features/messages/warpVisualization/useWarpRouteBalances.ts
+++ b/src/features/messages/warpVisualization/useWarpRouteBalances.ts
@@ -10,8 +10,16 @@ import { useMemo } from 'react';
 import { useMultiProviderVersion, useReadyMultiProvider } from '../../../store';
 import { logger } from '../../../utils/logger';
 import type { ExplorerMultiProvider as MultiProtocolProvider } from '../../hyperlane/sdkRuntime';
-import { ChainBalance, WarpRouteBalances, WarpRouteTokenVisualization } from './types';
+import { SUPPORTED_SEALEVEL_BALANCE_STANDARDS } from './tokenStandards';
+import {
+  ChainBalance,
+  getWarpRouteTokenKey,
+  WarpRouteBalances,
+  WarpRouteTokenVisualization,
+} from './types';
 import { isCollateralTokenStandard } from './useWarpRouteVisualization';
+
+const BALANCE_STALE_TIME_MS = 15_000;
 
 // Token standards that support balance fetching
 // NOTE: Only EVM chains are supported for balance fetching.
@@ -19,6 +27,7 @@ import { isCollateralTokenStandard } from './useWarpRouteVisualization';
 // that cause build errors when imported in the browser bundle.
 const SUPPORTED_COLLATERAL_STANDARDS: TokenStandard[] = [
   TokenStandard.EvmHypCollateral,
+  TokenStandard.EvmHypCrossCollateralRouter,
   TokenStandard.EvmHypNative,
   TokenStandard.EvmHypXERC20Lockbox,
   TokenStandard.EvmHypVSXERC20Lockbox,
@@ -54,6 +63,40 @@ function isSupportedXERC20Standard(standard: TokenStandard | string | undefined)
   return SUPPORTED_XERC20_STANDARDS.includes(standard as TokenStandard);
 }
 
+function isSupportedSealevelStandard(standard: TokenStandard | string | undefined): boolean {
+  if (!standard) return false;
+  return SUPPORTED_SEALEVEL_BALANCE_STANDARDS.includes(standard as TokenStandard);
+}
+
+function getApiBalance(data: unknown): bigint | undefined {
+  if (!data || typeof data !== 'object') return undefined;
+  const { balance } = data as Record<string, unknown>;
+  if (typeof balance !== 'string') return undefined;
+  return BigInt(balance);
+}
+
+async function fetchSealevelTokenBalance(
+  token: WarpRouteTokenVisualization,
+): Promise<ChainBalance | undefined> {
+  const params = new URLSearchParams({
+    chainName: token.chainName,
+    addressOrDenom: token.addressOrDenom,
+    standard: token.standard || '',
+  });
+  if (token.collateralAddressOrDenom) {
+    params.set('collateralAddressOrDenom', token.collateralAddressOrDenom);
+  }
+
+  const response = await fetch(`/api/sealevel-warp-route-balance?${params.toString()}`);
+  if (!response.ok) {
+    logger.debug(`Sealevel balance API ${response.status} for ${token.chainName}:${token.symbol}`);
+    return undefined;
+  }
+
+  const balance = getApiBalance(await response.json());
+  return balance === undefined ? undefined : { balance };
+}
+
 /**
  * Fetch the balance data for a single token
  */
@@ -62,6 +105,10 @@ async function fetchTokenBalance(
   token: WarpRouteTokenVisualization,
 ): Promise<ChainBalance | undefined> {
   try {
+    if (isSupportedSealevelStandard(token.standard)) {
+      return await fetchSealevelTokenBalance(token);
+    }
+
     const adapter = createEvmHypAdapter(multiProvider, token);
     if (!adapter) {
       return undefined;
@@ -116,6 +163,7 @@ function shouldFetchSupply(token: WarpRouteTokenVisualization): boolean {
   return (
     isCollateralTokenStandard(token.standard) ||
     isSupportedCollateralStandard(token.standard) ||
+    isSupportedSealevelStandard(token.standard) ||
     isSupportedXERC20Standard(token.standard) ||
     isSupportedSyntheticStandard(token.standard)
   );
@@ -133,7 +181,7 @@ async function fetchAllBalances(
   const promises = tokens.map(async (token) => {
     const balance = await fetchTokenBalance(multiProvider, token);
     if (balance !== undefined) {
-      balances[token.chainName] = balance;
+      balances[getWarpRouteTokenKey(token)] = balance;
     }
   });
 
@@ -162,7 +210,15 @@ export function useWarpRouteBalances(
   // Create a stable string key from tokens - this prevents queryKey from changing
   // when tokensToFetch array reference changes but content is the same
   const tokensKey = useMemo(
-    () => tokensToFetch.map((t) => `${t.chainName}:${t.addressOrDenom}`).join(','),
+    () =>
+      tokensToFetch
+        .map(
+          (t) =>
+            `${t.chainName}:${t.addressOrDenom}:${t.standard || ''}:${
+              t.collateralAddressOrDenom || ''
+            }`,
+        )
+        .join(','),
     [tokensToFetch],
   );
 
@@ -174,6 +230,7 @@ export function useWarpRouteBalances(
   const {
     data: balances,
     isLoading,
+    isFetching,
     error,
     refetch,
   } = useQuery({
@@ -184,15 +241,16 @@ export function useWarpRouteBalances(
       return fetchAllBalances(multiProvider, tokensToFetch);
     },
     enabled: enabled && !!multiProvider && tokensToFetch.length > 0 && !!routeId,
-    staleTime: Infinity,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
+    staleTime: BALANCE_STALE_TIME_MS,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
   });
 
   return {
     balances: balances || {},
     isLoading,
+    isFetching,
     error: error ? String(error) : undefined,
     refetch,
   };

--- a/src/features/messages/warpVisualization/useWarpRouteVisualization.test.ts
+++ b/src/features/messages/warpVisualization/useWarpRouteVisualization.test.ts
@@ -1,0 +1,185 @@
+import { TokenStandard } from '@hyperlane-xyz/sdk/token/TokenStandard';
+import type { WarpRouteConfigs } from '@hyperlane-xyz/sdk/warp/read';
+import type { WarpCoreConfig } from '@hyperlane-xyz/sdk/warp/types';
+
+import { isCrossCollateralTokenStandard } from './tokenStandards';
+import { getWarpRouteTokenKey } from './types';
+import { findWarpRouteConfig, isCollateralTokenStandard } from './useWarpRouteVisualization';
+
+const ETH_USDC = '0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F';
+const ETH_USDT = '0xeB1b48b238E15A62e1858a601B6BfFdf41163AE3';
+const SOL_XO = 'HW9NfLGo6YMoM6o5auTvn5h26tWJPpsroUDfGFwvsQsU';
+
+function route(tokens: WarpCoreConfig['tokens']): WarpCoreConfig {
+  return { tokens };
+}
+
+function token(
+  chainName: string,
+  addressOrDenom: string,
+  standard: TokenStandard,
+): WarpCoreConfig['tokens'][number] {
+  return {
+    chainName,
+    addressOrDenom,
+    standard,
+    symbol: 'TEST',
+    name: 'Test',
+    decimals: 6,
+  };
+}
+
+describe('findWarpRouteConfig', () => {
+  it('prefers the specific cross-collateral sub-route when routers appear in multiple routes', () => {
+    const configs: WarpRouteConfigs = {
+      'CROSS/moonpay': route([
+        token('ethereum', ETH_USDC, TokenStandard.EvmHypCrossCollateralRouter),
+        token('ethereum', ETH_USDT, TokenStandard.EvmHypCrossCollateralRouter),
+        token('solanamainnet', SOL_XO, TokenStandard.SealevelHypCrossCollateral),
+      ]),
+      'USDC/moonpay': route([
+        token('ethereum', ETH_USDC, TokenStandard.EvmHypCrossCollateralRouter),
+        token('solanamainnet', SOL_XO, TokenStandard.SealevelHypCrossCollateral),
+      ]),
+    };
+
+    const match = findWarpRouteConfig(
+      configs,
+      ETH_USDC.toLowerCase(),
+      'ethereum',
+      SOL_XO,
+      'solanamainnet',
+    );
+
+    expect(match?.routeId).toBe('USDC/moonpay');
+  });
+
+  it('uses route ID as a deterministic tiebreaker for equally-sized routes', () => {
+    const configs: WarpRouteConfigs = {
+      'z-route': route([
+        token('ethereum', ETH_USDC, TokenStandard.EvmHypCrossCollateralRouter),
+        token('solanamainnet', SOL_XO, TokenStandard.SealevelHypCrossCollateral),
+      ]),
+      'a-route': route([
+        token('ethereum', ETH_USDC, TokenStandard.EvmHypCrossCollateralRouter),
+        token('solanamainnet', SOL_XO, TokenStandard.SealevelHypCrossCollateral),
+      ]),
+    };
+
+    const match = findWarpRouteConfig(configs, ETH_USDC, 'ethereum', SOL_XO, 'solanamainnet');
+
+    expect(match?.routeId).toBe('a-route');
+  });
+
+  it('keeps the single-token lookup path on the most specific matching route', () => {
+    const configs: WarpRouteConfigs = {
+      'CROSS/moonpay': route([
+        token('ethereum', ETH_USDC, TokenStandard.EvmHypCrossCollateralRouter),
+        token('ethereum', ETH_USDT, TokenStandard.EvmHypCrossCollateralRouter),
+        token('solanamainnet', SOL_XO, TokenStandard.SealevelHypCrossCollateral),
+      ]),
+      'USDC/moonpay': route([
+        token('ethereum', ETH_USDC, TokenStandard.EvmHypCrossCollateralRouter),
+        token('solanamainnet', SOL_XO, TokenStandard.SealevelHypCrossCollateral),
+      ]),
+    };
+
+    const match = findWarpRouteConfig(configs, ETH_USDC, 'ethereum');
+
+    expect(match?.routeId).toBe('USDC/moonpay');
+  });
+
+  it('prefers a matching warp route ID over the smallest matching config', () => {
+    const configs: WarpRouteConfigs = {
+      'M0/smaller': route([
+        token('ethereum', ETH_USDC, TokenStandard.EvmHypCollateral),
+        token('solanamainnet', SOL_XO, TokenStandard.SealevelHypSynthetic),
+      ]),
+      'USDSC/mUSD/wM': route([
+        token('ethereum', ETH_USDC, TokenStandard.EvmHypCollateral),
+        token('solanamainnet', SOL_XO, TokenStandard.SealevelHypSynthetic),
+        token('ethereum', ETH_USDT, TokenStandard.EvmHypCollateral),
+      ]),
+    };
+
+    const match = findWarpRouteConfig(
+      configs,
+      ETH_USDC,
+      'ethereum',
+      SOL_XO,
+      'solanamainnet',
+      'USDSC/mUSD/wM',
+    );
+
+    expect(match?.routeId).toBe('USDSC/mUSD/wM');
+  });
+
+  it('falls back when the preferred warp route ID does not match the transfer', () => {
+    const configs: WarpRouteConfigs = {
+      'unrelated-route': route([token('ethereum', ETH_USDT, TokenStandard.EvmHypCollateral)]),
+      'USDC/moonpay': route([
+        token('ethereum', ETH_USDC, TokenStandard.EvmHypCrossCollateralRouter),
+        token('solanamainnet', SOL_XO, TokenStandard.SealevelHypCrossCollateral),
+      ]),
+    };
+
+    const match = findWarpRouteConfig(
+      configs,
+      ETH_USDC,
+      'ethereum',
+      SOL_XO,
+      'solanamainnet',
+      'unrelated-route',
+    );
+
+    expect(match?.routeId).toBe('USDC/moonpay');
+  });
+
+  it('uses a destination chain filter even without a destination token address', () => {
+    const configs: WarpRouteConfigs = {
+      'ethereum-only': route([
+        token('ethereum', ETH_USDC, TokenStandard.EvmHypCollateral),
+        token('ethereum', ETH_USDT, TokenStandard.EvmHypSynthetic),
+      ]),
+      'ethereum-solana': route([
+        token('ethereum', ETH_USDC, TokenStandard.EvmHypCollateral),
+        token('solanamainnet', SOL_XO, TokenStandard.SealevelHypSynthetic),
+      ]),
+    };
+
+    const match = findWarpRouteConfig(configs, ETH_USDC, 'ethereum', undefined, 'solanamainnet');
+
+    expect(match?.routeId).toBe('ethereum-solana');
+  });
+});
+
+describe('getWarpRouteTokenKey', () => {
+  it('keeps same-chain sibling token balances distinct', () => {
+    expect(
+      getWarpRouteTokenKey({
+        chainName: 'ethereum',
+        addressOrDenom: ETH_USDC,
+      }),
+    ).not.toBe(
+      getWarpRouteTokenKey({
+        chainName: 'ethereum',
+        addressOrDenom: ETH_USDT,
+      }),
+    );
+  });
+});
+
+describe('isCollateralTokenStandard', () => {
+  it('treats cross-collateral routers as collateral-backed', () => {
+    expect(isCollateralTokenStandard(TokenStandard.EvmHypCrossCollateralRouter)).toBe(true);
+    expect(isCollateralTokenStandard(TokenStandard.SealevelHypCrossCollateral)).toBe(true);
+    expect(isCollateralTokenStandard(TokenStandard.TronHypCrossCollateralRouter)).toBe(true);
+  });
+});
+
+describe('isCrossCollateralTokenStandard', () => {
+  it('detects cross-collateral standards without importing UI components', () => {
+    expect(isCrossCollateralTokenStandard(TokenStandard.EvmHypCrossCollateralRouter)).toBe(true);
+    expect(isCrossCollateralTokenStandard(TokenStandard.EvmHypCollateral)).toBe(false);
+  });
+});

--- a/src/features/messages/warpVisualization/useWarpRouteVisualization.test.ts
+++ b/src/features/messages/warpVisualization/useWarpRouteVisualization.test.ts
@@ -3,7 +3,7 @@ import type { WarpRouteConfigs } from '@hyperlane-xyz/sdk/warp/read';
 import type { WarpCoreConfig } from '@hyperlane-xyz/sdk/warp/types';
 
 import { isCrossCollateralTokenStandard } from './tokenStandards';
-import { getWarpRouteTokenKey } from './types';
+import { getWarpRouteTokenKey, hasRouteEnrollments } from './types';
 import { findWarpRouteConfig, isCollateralTokenStandard } from './useWarpRouteVisualization';
 
 const ETH_USDC = '0xA9C9a8FB36Ce3e5ffBAC3757dA7141262723541F';
@@ -181,5 +181,32 @@ describe('isCrossCollateralTokenStandard', () => {
   it('detects cross-collateral standards without importing UI components', () => {
     expect(isCrossCollateralTokenStandard(TokenStandard.EvmHypCrossCollateralRouter)).toBe(true);
     expect(isCrossCollateralTokenStandard(TokenStandard.EvmHypCollateral)).toBe(false);
+  });
+});
+
+describe('hasRouteEnrollments', () => {
+  it('detects enrollments on non-cross-collateral routes', () => {
+    expect(
+      hasRouteEnrollments({
+        routeId: 'normal-route',
+        config: route([]),
+        tokens: [
+          {
+            chainName: 'ethereum',
+            addressOrDenom: ETH_USDC,
+            standard: TokenStandard.EvmHypCollateral,
+            symbol: 'USDC',
+            decimals: 6,
+            enrollments: [
+              {
+                chainName: 'solanamainnet',
+                addressOrDenom: SOL_XO,
+                symbol: 'XO',
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(true);
   });
 });

--- a/src/features/messages/warpVisualization/useWarpRouteVisualization.ts
+++ b/src/features/messages/warpVisualization/useWarpRouteVisualization.ts
@@ -1,30 +1,128 @@
-import type { WarpCoreConfig } from '@hyperlane-xyz/sdk';
+import { parseTokenConnectionId } from '@hyperlane-xyz/sdk/token/TokenConnection';
+import { TokenStandard } from '@hyperlane-xyz/sdk/token/TokenStandard';
 import type { WarpRouteConfigs } from '@hyperlane-xyz/sdk/warp/read';
+import type { WarpCoreConfig } from '@hyperlane-xyz/sdk/warp/types';
 import { useMemo } from 'react';
 
 import { useStore } from '../../../store';
 import { WarpRouteDetails } from '../../../types';
+import { logger } from '../../../utils/logger';
 import { normalizeAddressToHex } from '../../../utils/yamlParsing';
-import { WarpRouteTokenVisualization, WarpRouteVisualization } from './types';
+import { COLLATERAL_TOKEN_STANDARDS } from './tokenStandards';
+import { WarpRouteEnrollment, WarpRouteTokenVisualization, WarpRouteVisualization } from './types';
 
 /**
  * Find the warp route config that contains the given token address on the given chain
  */
-function findWarpRouteConfig(
+function tokenMatches(
+  token: WarpCoreConfig['tokens'][number],
+  tokenAddress: string,
+  chainName: string,
+) {
+  // This compares registry entries against decoded message addresses across protocols.
+  // `normalizeAddress` needs a known protocol; this helper also preserves denom fallbacks.
+  return (
+    token.chainName === chainName &&
+    token.addressOrDenom &&
+    normalizeAddressToHex(token.addressOrDenom) === normalizeAddressToHex(tokenAddress)
+  );
+}
+
+function tokenMatchesOptionalEndpoint(
+  token: WarpCoreConfig['tokens'][number],
+  tokenAddress?: string,
+  chainName?: string,
+) {
+  if (chainName && token.chainName !== chainName) return false;
+  if (!tokenAddress) return !!chainName;
+  return (
+    !!token.addressOrDenom &&
+    normalizeAddressToHex(token.addressOrDenom) === normalizeAddressToHex(tokenAddress)
+  );
+}
+
+function routeMatches(
+  config: WarpCoreConfig,
+  tokenAddress: string,
+  chainName: string,
+  destinationTokenAddress?: string,
+  destinationChainName?: string,
+): boolean {
+  const matchesOrigin = config.tokens.some((token) => tokenMatches(token, tokenAddress, chainName));
+  if (!matchesOrigin) return false;
+
+  if (!destinationTokenAddress && !destinationChainName) return true;
+  return config.tokens.some((token) =>
+    tokenMatchesOptionalEndpoint(token, destinationTokenAddress, destinationChainName),
+  );
+}
+
+export function findWarpRouteConfig(
   warpRouteConfigs: WarpRouteConfigs,
   tokenAddress: string,
   chainName: string,
+  destinationTokenAddress?: string,
+  destinationChainName?: string,
+  preferredRouteId?: string,
 ): { routeId: string; config: WarpCoreConfig } | undefined {
-  for (const [routeId, config] of Object.entries(warpRouteConfigs)) {
-    const match = config.tokens.find(
-      (t) =>
-        t.chainName === chainName &&
-        t.addressOrDenom &&
-        normalizeAddressToHex(t.addressOrDenom) === normalizeAddressToHex(tokenAddress),
-    );
-    if (match) return { routeId, config };
+  const preferredConfig = preferredRouteId ? warpRouteConfigs[preferredRouteId] : undefined;
+  if (
+    preferredRouteId &&
+    preferredConfig &&
+    routeMatches(
+      preferredConfig,
+      tokenAddress,
+      chainName,
+      destinationTokenAddress,
+      destinationChainName,
+    )
+  ) {
+    return { routeId: preferredRouteId, config: preferredConfig };
   }
-  return undefined;
+
+  let bestMatch: { routeId: string; config: WarpCoreConfig } | undefined;
+
+  for (const [routeId, config] of Object.entries(warpRouteConfigs)) {
+    if (
+      !routeMatches(config, tokenAddress, chainName, destinationTokenAddress, destinationChainName)
+    )
+      continue;
+
+    // Tokens can appear in both broad cross-collateral routes and narrower sub-routes.
+    // Prefer the most specific matching route, with routeId as a deterministic tiebreaker.
+    if (
+      !bestMatch ||
+      config.tokens.length < bestMatch.config.tokens.length ||
+      (config.tokens.length === bestMatch.config.tokens.length &&
+        routeId.localeCompare(bestMatch.routeId) < 0)
+    ) {
+      bestMatch = { routeId, config };
+    }
+  }
+
+  return bestMatch;
+}
+
+function getTokenKey(chainName: string, addressOrDenom: string) {
+  return `${chainName}:${normalizeAddressToHex(addressOrDenom)}`;
+}
+
+function parseEnrollment(
+  tokenId: string,
+  tokenByKey: Map<string, WarpCoreConfig['tokens'][number]>,
+): WarpRouteEnrollment | undefined {
+  try {
+    const { chainName, addressOrDenom } = parseTokenConnectionId(tokenId);
+    const token = tokenByKey.get(getTokenKey(chainName, addressOrDenom));
+    return {
+      chainName,
+      addressOrDenom,
+      symbol: token?.symbol || '',
+    };
+  } catch (error) {
+    logger.debug('Failed to parse warp route token connection', { error, tokenId });
+    return undefined;
+  }
 }
 
 /**
@@ -40,15 +138,39 @@ export function useWarpRouteVisualization(warpRouteDetails: WarpRouteDetails | u
   // Memoize based on the actual values that matter, not the object references
   const originTokenAddress = warpRouteDetails?.originToken.addressOrDenom;
   const originChainName = warpRouteDetails?.originToken.chainName;
+  const destinationTokenAddress = warpRouteDetails?.destinationToken.addressOrDenom;
+  const destinationChainName = warpRouteDetails?.destinationToken.chainName;
+  const preferredRouteId =
+    warpRouteDetails?.originToken.warpRouteId || warpRouteDetails?.destinationToken.warpRouteId;
 
   const warpRoute = useMemo(() => {
     if (!originTokenAddress) return undefined;
-    return findWarpRouteConfig(warpRouteConfigs, originTokenAddress, originChainName!);
-  }, [warpRouteConfigs, originTokenAddress, originChainName]);
+    return findWarpRouteConfig(
+      warpRouteConfigs,
+      originTokenAddress,
+      originChainName!,
+      destinationTokenAddress,
+      destinationChainName,
+      preferredRouteId,
+    );
+  }, [
+    warpRouteConfigs,
+    originTokenAddress,
+    originChainName,
+    destinationTokenAddress,
+    destinationChainName,
+    preferredRouteId,
+  ]);
 
   // Build the visualization data directly from registry config
   const visualization = useMemo((): WarpRouteVisualization | undefined => {
     if (!warpRoute) return undefined;
+
+    const tokenByKey = new Map(
+      warpRoute.config.tokens
+        .filter((token) => token.addressOrDenom)
+        .map((token) => [getTokenKey(token.chainName, token.addressOrDenom!), token]),
+    );
 
     const tokens: WarpRouteTokenVisualization[] = warpRoute.config.tokens.map((token) => ({
       chainName: token.chainName,
@@ -56,6 +178,11 @@ export function useWarpRouteVisualization(warpRouteDetails: WarpRouteDetails | u
       symbol: token.symbol || '',
       decimals: token.decimals ?? 18,
       standard: token.standard,
+      collateralAddressOrDenom: token.collateralAddressOrDenom,
+      enrollments:
+        token.connections
+          ?.map((connection) => parseEnrollment(connection.token, tokenByKey))
+          .filter((enrollment): enrollment is WarpRouteEnrollment => Boolean(enrollment)) ?? [],
       logoURI: token.logoURI,
     }));
 
@@ -69,27 +196,10 @@ export function useWarpRouteVisualization(warpRouteDetails: WarpRouteDetails | u
   return { visualization };
 }
 
-// Token standards that indicate collateral-backed tokens
-const COLLATERAL_TOKEN_STANDARDS = [
-  'EvmHypCollateral',
-  'EvmHypCollateralFiat',
-  'EvmHypNative',
-  'EvmHypNativeScaled',
-  'EvmHypXERC20Lockbox',
-  'EvmHypVSXERC20Lockbox',
-  'SealevelHypCollateral',
-  'SealevelHypNative',
-  'CwHypCollateral',
-  'CwHypNative',
-  'CosmosIbc', // IBC tokens often represent collateral
-  'StarknetHypCollateral',
-  'StarknetHypNative',
-];
-
 /**
  * Check if a token standard indicates a collateral-backed token
  */
 export function isCollateralTokenStandard(standard: string | undefined): boolean {
   if (!standard) return false;
-  return COLLATERAL_TOKEN_STANDARDS.includes(standard);
+  return COLLATERAL_TOKEN_STANDARDS.includes(standard as TokenStandard);
 }

--- a/src/pages/api/sealevel-warp-route-balance.ts
+++ b/src/pages/api/sealevel-warp-route-balance.ts
@@ -1,0 +1,227 @@
+import { GithubRegistry } from '@hyperlane-xyz/registry';
+import type { ChainMetadata } from '@hyperlane-xyz/sdk/metadata/chainMetadataTypes';
+import { MultiProviderAdapter } from '@hyperlane-xyz/sdk/providers/MultiProviderAdapter';
+import { defaultSolProviderBuilder } from '@hyperlane-xyz/sdk/providers/providerBuilders';
+import { ProviderType } from '@hyperlane-xyz/sdk/providers/ProviderType';
+import { createSealevelHypAdapter } from '@hyperlane-xyz/sdk/token/adapters/sealevelHyp';
+import { TokenStandard } from '@hyperlane-xyz/sdk/token/TokenStandard';
+import type { WarpRouteConfigs } from '@hyperlane-xyz/sdk/warp/read';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { config } from '../../consts/config';
+import { SUPPORTED_SEALEVEL_BALANCE_STANDARDS } from '../../features/messages/warpVisualization/tokenStandards';
+import { logger } from '../../utils/logger';
+
+const SEALEVEL_STANDARDS = new Set<string>(SUPPORTED_SEALEVEL_BALANCE_STANDARDS);
+const MISSING_BALANCE_ACCOUNT_ERRORS = ['could not find account'];
+const REGISTRY_DATA_CACHE_MS = 5 * 60 * 1000;
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const BASE58_VALUES = new Map([...BASE58_ALPHABET].map((char, index) => [char, index]));
+const SEALEVEL_STANDARDS_REQUIRING_COLLATERAL = new Set<string>([
+  TokenStandard.SealevelHypCollateral,
+  TokenStandard.SealevelHypCrossCollateral,
+  TokenStandard.SealevelHypSynthetic,
+]);
+
+interface RegistryData {
+  chains: Record<string, ChainMetadata>;
+  warpRouteConfigs: WarpRouteConfigs;
+}
+
+let registryDataRequest: Promise<RegistryData> | null = null;
+let registryDataExpiresAt = 0;
+const multiProviders = new Map<string, MultiProviderAdapter<{ mailbox?: string }>>();
+
+function getSingleQueryParam(value: string | string[] | undefined): string | undefined {
+  if (typeof value === 'string') return value;
+  return undefined;
+}
+
+function isMissingBalanceAccountError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const lowerMessage = message.toLowerCase();
+  return MISSING_BALANCE_ACCOUNT_ERRORS.some((snippet) => lowerMessage.includes(snippet));
+}
+
+function isValidSealevelAddress(value: string): boolean {
+  const bytes = decodeBase58(value);
+  return bytes?.length === 32;
+}
+
+function decodeBase58(value: string): number[] | undefined {
+  if (!value) return undefined;
+
+  const bytes = [0];
+  for (const char of value) {
+    const charValue = BASE58_VALUES.get(char);
+    if (charValue === undefined) return undefined;
+
+    let carry = charValue;
+    for (let i = 0; i < bytes.length; i++) {
+      carry += bytes[i] * 58;
+      bytes[i] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+
+  for (const char of value) {
+    if (char !== '1') break;
+    bytes.push(0);
+  }
+
+  return bytes.reverse();
+}
+
+function getMultiProvider(chainName: string, chain: ChainMetadata) {
+  const cached = multiProviders.get(chainName);
+  if (cached) return cached;
+
+  const multiProvider = new MultiProviderAdapter(
+    { [chainName]: chain as ChainMetadata<{ mailbox?: string }> },
+    { providerBuilders: { [ProviderType.SolanaWeb3]: defaultSolProviderBuilder } },
+  );
+  multiProviders.set(chainName, multiProvider);
+  return multiProvider;
+}
+
+function isRegisteredTokenRequest(
+  warpRouteConfigs: WarpRouteConfigs,
+  {
+    chainName,
+    addressOrDenom,
+    collateralAddressOrDenom,
+    standard,
+  }: {
+    chainName: string;
+    addressOrDenom: string;
+    collateralAddressOrDenom?: string;
+    standard: string;
+  },
+): boolean {
+  return Object.values(warpRouteConfigs).some((config) =>
+    config.tokens.some(
+      (token) =>
+        token.chainName === chainName &&
+        token.addressOrDenom === addressOrDenom &&
+        token.standard === standard &&
+        (token.collateralAddressOrDenom || undefined) === collateralAddressOrDenom,
+    ),
+  );
+}
+
+async function getRegistryData() {
+  if (!registryDataRequest || (registryDataExpiresAt > 0 && Date.now() >= registryDataExpiresAt)) {
+    registryDataExpiresAt = 0;
+    multiProviders.clear();
+    const registry = new GithubRegistry({
+      proxyUrl: config.githubProxy,
+      uri: config.registryUrl,
+      branch: config.registryBranch,
+    });
+    registryDataRequest = Promise.all([
+      registry.getMetadata(),
+      registry.getAddresses(),
+      registry.getWarpRoutes(),
+    ])
+      .then(([metadata, addresses, warpRouteConfigs]) => {
+        const chains: Record<string, ChainMetadata> = {};
+        for (const [chainName, chainMetadata] of Object.entries(metadata)) {
+          chains[chainName] = {
+            ...chainMetadata,
+            ...addresses[chainName],
+          };
+        }
+        registryDataExpiresAt = Date.now() + REGISTRY_DATA_CACHE_MS;
+        return { chains, warpRouteConfigs };
+      })
+      .catch((error) => {
+        registryDataRequest = null;
+        registryDataExpiresAt = 0;
+        multiProviders.clear();
+        throw error;
+      });
+  }
+  return registryDataRequest;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const chainName = getSingleQueryParam(req.query.chainName);
+  const addressOrDenom = getSingleQueryParam(req.query.addressOrDenom);
+  const collateralAddressOrDenom = getSingleQueryParam(req.query.collateralAddressOrDenom);
+  const standard = getSingleQueryParam(req.query.standard);
+
+  if (!chainName || !addressOrDenom || !standard || !SEALEVEL_STANDARDS.has(standard)) {
+    return res.status(400).json({ error: 'Unsupported balance request' });
+  }
+
+  if (
+    !isValidSealevelAddress(addressOrDenom) ||
+    (!!collateralAddressOrDenom && !isValidSealevelAddress(collateralAddressOrDenom))
+  ) {
+    return res.status(400).json({ error: 'Invalid Sealevel address' });
+  }
+
+  if (SEALEVEL_STANDARDS_REQUIRING_COLLATERAL.has(standard) && !collateralAddressOrDenom) {
+    return res.status(400).json({ error: 'Missing collateral address' });
+  }
+
+  try {
+    const { chains, warpRouteConfigs } = await getRegistryData();
+    const chain = chains[chainName];
+    if (!chain || chain.protocol !== 'sealevel') {
+      return res.status(400).json({ error: 'Unsupported chain' });
+    }
+
+    if (
+      !isRegisteredTokenRequest(warpRouteConfigs, {
+        chainName,
+        addressOrDenom,
+        collateralAddressOrDenom,
+        standard,
+      })
+    ) {
+      return res.status(400).json({ error: 'Unknown warp route token' });
+    }
+
+    const multiProvider = getMultiProvider(chainName, chain);
+    const adapter = createSealevelHypAdapter(multiProvider, {
+      chainName,
+      addressOrDenom,
+      collateralAddressOrDenom,
+      standard,
+    });
+    if (!adapter) {
+      return res.status(400).json({ error: 'Unsupported token' });
+    }
+
+    const balance = await adapter.getBridgedSupply();
+    if (balance === undefined) {
+      return res.status(404).json({ error: 'Balance unavailable' });
+    }
+
+    res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate=60');
+    return res.status(200).json({ balance: balance.toString() });
+  } catch (error) {
+    if (isMissingBalanceAccountError(error)) {
+      logger.debug('sealevel-warp-route-balance missing balance account', {
+        chainName,
+        addressOrDenom,
+        standard,
+      });
+      res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate=60');
+      return res.status(200).json({ balance: '0' });
+    }
+
+    logger.error('sealevel-warp-route-balance failed', error);
+    return res.status(500).json({ error: 'Failed to fetch balance' });
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the cross-collateral warp route overview for messages like Ethereum USDC to Solana XO on `USDC/moonpay`.

- Added a server-side `/api/warp-route-balance` endpoint for Sealevel hyp-token bridged supply reads, keeping Solana runtime dependencies out of the browser bundle.
- Included Sealevel and EVM cross-collateral standards in warp route balance fetching/collateral classification.
- Made route matching prefer the specific origin+destination route when routers appear in both a broad cross route and a narrower sub-route.
- Parsed registry `connections` and rendered enrolled remote chain chips on route nodes so sub-route enrollment is visible.

## Validation

- `pnpm test src/features/messages/warpVisualization/useWarpRouteVisualization.test.ts --runInBand`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- Local API check returned `{"balance":"10467086358"}` for `solanamainnet` `HW9NfLGo6YMoM6o5auTvn5h26tWJPpsroUDfGFwvsQsU`.