### PR TITLE
feat: surface Sealevel + EVM cross-collateral balances in warp route graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@hyperlane-xyz/sdk": "33.0.2",
     "@hyperlane-xyz/utils": "33.0.2",
     "@hyperlane-xyz/widgets": "33.0.2",
+    "@solana/web3.js": "^1.98.4",
     "@tanstack/query-core": "^5.71.3",
     "@tanstack/react-query": "^5.62.3",
     "@vercel/og": "^0.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@hyperlane-xyz/widgets':
         specifier: 33.0.2
         version: 33.0.2(@cosmjs/amino@0.32.4)(@cosmjs/proto-signing@0.32.4)(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(@react-native-async-storage/async-storage@1.24.0(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.0.8)(react@19.2.4)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.71.3)(@tanstack/react-query@5.71.3(react@19.2.4))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@types/sinon-chai@4.0.0)(bs58@6.0.0)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(get-starknet-core@4.0.0)(immer@10.1.3)(react-dom@19.2.4(react@19.2.4))(react-native@0.82.1(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.0.8)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@6.0.2)(use-sync-external-store@1.2.2(react@19.2.4))(utf-8-validate@5.0.10)(zod@3.24.2)
+      '@solana/web3.js':
+        specifier: ^1.98.4
+        version: 1.98.4(bufferutil@4.0.8)(typescript@6.0.2)(utf-8-validate@5.0.10)
       '@tanstack/query-core':
         specifier: ^5.71.3
         version: 5.71.3
@@ -7085,10 +7088,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:

--- a/src/features/messages/warpVisualization/useWarpRouteBalances.ts
+++ b/src/features/messages/warpVisualization/useWarpRouteBalances.ts
@@ -13,15 +13,21 @@ import type { ExplorerMultiProvider as MultiProtocolProvider } from '../../hyper
 import { ChainBalance, WarpRouteBalances, WarpRouteTokenVisualization } from './types';
 import { isCollateralTokenStandard } from './useWarpRouteVisualization';
 
-// Token standards that support balance fetching
-// NOTE: Only EVM chains are supported for balance fetching.
-// Sealevel/StarkNet adapters require native dependencies (e.g., @solana/web3.js)
-// that cause build errors when imported in the browser bundle.
+// Token standards that support balance fetching via the EVM adapter path.
+// Sealevel collateral routes go through the /api/sealevel-balance route
+// because the SDK's Sealevel adapter depends on @solana/web3.js, which
+// breaks the browser bundle when imported directly.
 const SUPPORTED_COLLATERAL_STANDARDS: TokenStandard[] = [
   TokenStandard.EvmHypCollateral,
   TokenStandard.EvmHypNative,
+  TokenStandard.EvmHypCrossCollateralRouter,
   TokenStandard.EvmHypXERC20Lockbox,
   TokenStandard.EvmHypVSXERC20Lockbox,
+];
+
+const SUPPORTED_SEALEVEL_COLLATERAL_STANDARDS: TokenStandard[] = [
+  TokenStandard.SealevelHypCollateral,
+  TokenStandard.SealevelHypCrossCollateral,
 ];
 
 const SUPPORTED_XERC20_STANDARDS: TokenStandard[] = [
@@ -54,6 +60,41 @@ function isSupportedXERC20Standard(standard: TokenStandard | string | undefined)
   return SUPPORTED_XERC20_STANDARDS.includes(standard as TokenStandard);
 }
 
+function isSupportedSealevelCollateralStandard(
+  standard: TokenStandard | string | undefined,
+): boolean {
+  if (!standard) return false;
+  return SUPPORTED_SEALEVEL_COLLATERAL_STANDARDS.includes(standard as TokenStandard);
+}
+
+/**
+ * Fetch a Sealevel collateral balance via the server-side /api/sealevel-balance
+ * endpoint. This avoids pulling @solana/web3.js into the browser bundle.
+ */
+async function fetchSealevelTokenBalance(
+  token: WarpRouteTokenVisualization,
+): Promise<ChainBalance | undefined> {
+  const params = new URLSearchParams({
+    chain: token.chainName,
+    warpRouter: token.addressOrDenom,
+  });
+  try {
+    const response = await fetch(`/api/sealevel-balance?${params.toString()}`);
+    if (!response.ok) {
+      logger.debug(
+        `Sealevel balance endpoint returned ${response.status} for ${token.chainName}:${token.symbol}`,
+      );
+      return undefined;
+    }
+    const data = (await response.json()) as { balance?: string };
+    if (typeof data.balance !== 'string') return undefined;
+    return { balance: BigInt(data.balance) };
+  } catch (error) {
+    logger.debug(`Failed to fetch Sealevel balance for ${token.chainName}:${token.symbol}`, error);
+    return undefined;
+  }
+}
+
 /**
  * Fetch the balance data for a single token
  */
@@ -61,6 +102,9 @@ async function fetchTokenBalance(
   multiProvider: MultiProtocolProvider,
   token: WarpRouteTokenVisualization,
 ): Promise<ChainBalance | undefined> {
+  if (isSupportedSealevelCollateralStandard(token.standard)) {
+    return fetchSealevelTokenBalance(token);
+  }
   try {
     const adapter = createEvmHypAdapter(multiProvider, token);
     if (!adapter) {
@@ -117,7 +161,8 @@ function shouldFetchSupply(token: WarpRouteTokenVisualization): boolean {
     isCollateralTokenStandard(token.standard) ||
     isSupportedCollateralStandard(token.standard) ||
     isSupportedXERC20Standard(token.standard) ||
-    isSupportedSyntheticStandard(token.standard)
+    isSupportedSyntheticStandard(token.standard) ||
+    isSupportedSealevelCollateralStandard(token.standard)
   );
 }
 

--- a/src/features/messages/warpVisualization/useWarpRouteVisualization.ts
+++ b/src/features/messages/warpVisualization/useWarpRouteVisualization.ts
@@ -75,10 +75,12 @@ const COLLATERAL_TOKEN_STANDARDS = [
   'EvmHypCollateralFiat',
   'EvmHypNative',
   'EvmHypNativeScaled',
+  'EvmHypCrossCollateralRouter',
   'EvmHypXERC20Lockbox',
   'EvmHypVSXERC20Lockbox',
   'SealevelHypCollateral',
   'SealevelHypNative',
+  'SealevelHypCrossCollateral',
   'CwHypCollateral',
   'CwHypNative',
   'CosmosIbc', // IBC tokens often represent collateral

--- a/src/pages/api/sealevel-balance.ts
+++ b/src/pages/api/sealevel-balance.ts
@@ -1,0 +1,69 @@
+import { chainMetadata } from '@hyperlane-xyz/registry';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+import { Connection, PublicKey } from '@solana/web3.js';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { logger } from '../../utils/logger';
+
+// Seeds used by hyperlane-sealevel-token-collateral and -cross-collateral
+// to derive the escrow PDA that actually holds bridged collateral.
+const ESCROW_PDA_SEEDS = [
+  Buffer.from('hyperlane_token'),
+  Buffer.from('-'),
+  Buffer.from('escrow'),
+];
+
+type SuccessResponse = { balance: string };
+type ErrorResponse = { error: string };
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<SuccessResponse | ErrorResponse>,
+) {
+  const chain = typeof req.query.chain === 'string' ? req.query.chain : '';
+  const warpRouter = typeof req.query.warpRouter === 'string' ? req.query.warpRouter : '';
+
+  if (!chain || !warpRouter) {
+    return res.status(400).json({ error: 'Missing chain or warpRouter' });
+  }
+
+  const metadata = chainMetadata[chain];
+  if (!metadata) {
+    return res.status(404).json({ error: `Chain ${chain} not in registry` });
+  }
+  if (metadata.protocol !== ProtocolType.Sealevel) {
+    return res.status(400).json({ error: `Chain ${chain} is not sealevel` });
+  }
+
+  const rpcUrl = metadata.rpcUrls?.[0]?.http;
+  if (!rpcUrl) {
+    return res.status(500).json({ error: `No RPC URL configured for ${chain}` });
+  }
+
+  let programId: PublicKey;
+  try {
+    programId = new PublicKey(warpRouter);
+  } catch {
+    return res.status(400).json({ error: `Invalid warpRouter pubkey: ${warpRouter}` });
+  }
+
+  const [escrowPda] = PublicKey.findProgramAddressSync(ESCROW_PDA_SEEDS, programId);
+
+  const connection = new Connection(rpcUrl, 'confirmed');
+  try {
+    const response = await connection.getTokenAccountBalance(escrowPda);
+    // Hint downstream caches: balances change frequently enough that we
+    // don't want stale CDN copies, but a few seconds is fine.
+    res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate=60');
+    return res.status(200).json({ balance: response.value.amount });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // Missing escrow account is equivalent to a zero balance (e.g. a token
+    // that has never received deposits). Surface as zero, not an error.
+    if (msg.includes('could not find account') || msg.includes('Invalid param')) {
+      return res.status(200).json({ balance: '0' });
+    }
+    logger.error('Sealevel balance RPC error', { chain, warpRouter, error: msg });
+    return res.status(502).json({ error: msg });
+  }
+}


### PR DESCRIPTION
## Summary

- Add a new Next.js API route `/api/sealevel-balance` that uses `@solana/web3.js` server-side to derive the Hyperlane escrow PDA and call `getTokenAccountBalance` against the chain's registry RPC URL.
- Wire Sealevel collateral standards (`SealevelHypCollateral`, `SealevelHypCrossCollateral`) into `useWarpRouteBalances` via a `fetch('/api/sealevel-balance?...')` call. `@solana/web3.js` stays out of the browser bundle because it's only imported from `pages/api/*`.
- Add `EvmHypCrossCollateralRouter` to the supported EVM standards (the SDK adapter factory already handles it).
- Add `EvmHypCrossCollateralRouter` and `SealevelHypCrossCollateral` to the visualization's `COLLATERAL_TOKEN_STANDARDS` so the relevant nodes render their balance/supply pill.

## Why

The Warp Route Overview graph silently dropped balance pills for the Solana node and for every EVM cross-collateral router node on routes like `CROSS/moonpay`. Reported on cross-collateral message [`0xb805…2cc3`](https://explorer.hyperlane.xyz/message/0xb805ef31a4e045e9dbb78692ead2942de12544e4d624b3117b0a41f9a3f32cc3) (USDC ETH → XO Solana).

The cause was two missing entries: the standards weren't in the visualization's collateral list, and the balance hook only enabled the EVM adapter path. Cross-collateral PRs in the SDK added the standards months ago but the explorer never picked them up.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run build` — `/api/sealevel-balance` registered as a dynamic server route
- [x] Pre-existing jest failures unchanged (`scheduleWhenIdle.test.ts`, `fetchPiChainMessages.test.ts`)
- [ ] Manual: load message `0xb805ef31a4e045e9dbb78692ead2942de12544e4d624b3117b0a41f9a3f32cc3`, expand Warp Route Overview, verify Solana node and EVM USDC router nodes now render a balance pill