### PR TITLE
feat: show cross-collateral sub-route enrollments in warp route card

### DIFF
--- a/src/features/messages/cards/WarpRouteVisualizationCard.tsx
+++ b/src/features/messages/cards/WarpRouteVisualizationCard.tsx
@@ -8,6 +8,10 @@ import { Card } from '../../../components/layout/Card';
 import HubIcon from '../../../images/icons/hub.svg';
 import { useMultiProvider } from '../../../store';
 import { Message, MessageStub, WarpRouteDetails } from '../../../types';
+import {
+  CrossCollateralEnrollments,
+  hasCrossCollateralTokens,
+} from '../warpVisualization/CrossCollateralEnrollments';
 import { useWarpRouteBalances } from '../warpVisualization/useWarpRouteBalances';
 import { useWarpRouteVisualization } from '../warpVisualization/useWarpRouteVisualization';
 import { WarpRouteGraph } from '../warpVisualization/WarpRouteGraph';
@@ -110,6 +114,11 @@ export function WarpRouteVisualizationCard({ message, warpRouteDetails, blur }: 
               tokenSymbol={warpRouteDetails.originToken.symbol}
             />
           </div>
+
+          {/* Cross-collateral sub-route enrollments */}
+          {hasCrossCollateralTokens(visualization) && (
+            <CrossCollateralEnrollments visualization={visualization} />
+          )}
 
           {/* Refresh Balances Button */}
           <div className="flex justify-center">

--- a/src/features/messages/warpVisualization/CrossCollateralEnrollments.tsx
+++ b/src/features/messages/warpVisualization/CrossCollateralEnrollments.tsx
@@ -1,0 +1,153 @@
+import { shortenAddress } from '@hyperlane-xyz/utils';
+import { CopyButton } from '@hyperlane-xyz/widgets';
+
+import { ChainLogo } from '../../../components/icons/ChainLogo';
+import { useMultiProvider } from '../../../store';
+import {
+  TokenConnectionRef,
+  WarpRouteTokenVisualization,
+  WarpRouteVisualization,
+} from './types';
+
+// Token standards that participate in a cross-collateral router.
+// Kept in sync with the SDK's TOKEN_CROSS_COLLATERAL_STANDARDS — duplicated as
+// strings to avoid pulling the SDK type lookup into the render path.
+const CROSS_COLLATERAL_STANDARDS = new Set<string>([
+  'EvmHypCrossCollateralRouter',
+  'TronHypCrossCollateralRouter',
+  'SealevelHypCrossCollateral',
+]);
+
+function isCrossCollateralToken(token: WarpRouteTokenVisualization): boolean {
+  return !!token.standard && CROSS_COLLATERAL_STANDARDS.has(token.standard);
+}
+
+/**
+ * Whether the warp route has any cross-collateral sub-route on any chain.
+ * Used to gate the enrollment section, which is only meaningful when
+ * tokens can carry distinct sub-routes / collateral assets.
+ */
+export function hasCrossCollateralTokens(visualization: WarpRouteVisualization): boolean {
+  return visualization.tokens.some(isCrossCollateralToken);
+}
+
+interface Props {
+  visualization: WarpRouteVisualization;
+}
+
+/**
+ * Lists every token in the warp route alongside its cross-collateral
+ * enrollments (`connections` from the registry config). For routes that
+ * use a CrossCollateralRouter this exposes the sub-route structure that
+ * the main graph collapses into a flat token list.
+ */
+export function CrossCollateralEnrollments({ visualization }: Props) {
+  const multiProvider = useMultiProvider();
+
+  // Build a lookup so connection refs can resolve back to the rich token
+  // metadata (symbol, collateral asset) inside this same route.
+  const tokensByKey = new Map<string, WarpRouteTokenVisualization>();
+  for (const token of visualization.tokens) {
+    tokensByKey.set(tokenKey(token.chainName, token.addressOrDenom), token);
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="text-xs font-medium uppercase tracking-wide text-gray-500">
+        Cross-collateral sub-route enrollments
+      </div>
+      <div className="space-y-2">
+        {visualization.tokens.map((token) => (
+          <EnrollmentRow
+            key={tokenKey(token.chainName, token.addressOrDenom)}
+            token={token}
+            tokensByKey={tokensByKey}
+            multiProvider={multiProvider}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EnrollmentRow({
+  token,
+  tokensByKey,
+  multiProvider,
+}: {
+  token: WarpRouteTokenVisualization;
+  tokensByKey: Map<string, WarpRouteTokenVisualization>;
+  multiProvider: ReturnType<typeof useMultiProvider>;
+}) {
+  const displayName =
+    multiProvider.tryGetChainMetadata(token.chainName)?.displayName || token.chainName;
+
+  const enrollments = token.enrollments ?? [];
+
+  return (
+    <div className="rounded-md border border-gray-200 bg-white p-3 text-xs">
+      <div className="flex flex-wrap items-center gap-2">
+        <ChainLogo chainName={token.chainName} size={18} />
+        <span className="font-semibold">{displayName}</span>
+        <span className="rounded bg-gray-100 px-1.5 py-0.5 font-medium text-gray-700">
+          {token.symbol || '—'}
+        </span>
+        {token.collateralAddressOrDenom && (
+          <span className="flex items-center gap-1 text-[10px] text-gray-500">
+            collateral
+            <span className="font-mono">{shortenAddress(token.collateralAddressOrDenom)}</span>
+            <CopyButton
+              copyValue={token.collateralAddressOrDenom}
+              width={10}
+              height={10}
+              className="opacity-50"
+            />
+          </span>
+        )}
+        <span className="ml-auto text-[10px] text-gray-500">
+          {enrollments.length} enrollment{enrollments.length === 1 ? '' : 's'}
+        </span>
+      </div>
+      {enrollments.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {enrollments.map((enrollment) => (
+            <EnrollmentChip
+              key={enrollment.raw}
+              connection={enrollment}
+              peer={tokensByKey.get(tokenKey(enrollment.chainName, enrollment.addressOrDenom))}
+              multiProvider={multiProvider}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EnrollmentChip({
+  connection,
+  peer,
+  multiProvider,
+}: {
+  connection: TokenConnectionRef;
+  peer: WarpRouteTokenVisualization | undefined;
+  multiProvider: ReturnType<typeof useMultiProvider>;
+}) {
+  const displayName =
+    multiProvider.tryGetChainMetadata(connection.chainName)?.displayName || connection.chainName;
+
+  return (
+    <span className="flex items-center gap-1 rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5">
+      <ChainLogo chainName={connection.chainName} size={12} />
+      <span className="font-medium">{displayName}</span>
+      {peer?.symbol && <span className="text-gray-600">· {peer.symbol}</span>}
+      <span className="font-mono text-[10px] text-gray-500">
+        {shortenAddress(connection.addressOrDenom)}
+      </span>
+    </span>
+  );
+}
+
+function tokenKey(chainName: string, addressOrDenom: string): string {
+  return `${chainName}:${addressOrDenom.toLowerCase()}`;
+}

--- a/src/features/messages/warpVisualization/types.ts
+++ b/src/features/messages/warpVisualization/types.ts
@@ -9,9 +9,24 @@ export interface WarpRouteTokenVisualization {
   decimals: number;
   standard?: TokenStandard;
   logoURI?: string;
+  collateralAddressOrDenom?: string;
+  // Cross-collateral sub-route enrollments. Each entry is the
+  // `protocol|chainName|addressOrDenom` token reference parsed from
+  // the WarpCoreConfig token's `connections` field. Named distinctly
+  // from `connections` so this shape stays compatible with the SDK's
+  // HypTokenAdapterInput when passed to adapter factories.
+  enrollments?: TokenConnectionRef[];
   // Balance data (fetched via adapters when expanded)
   collateralBalance?: bigint;
   isCollateralInsufficient?: boolean;
+}
+
+// Parsed `protocol|chainName|address` connection reference.
+export interface TokenConnectionRef {
+  raw: string;
+  protocol: string;
+  chainName: string;
+  addressOrDenom: string;
 }
 
 export interface WarpRouteVisualization {

--- a/src/features/messages/warpVisualization/useWarpRouteVisualization.ts
+++ b/src/features/messages/warpVisualization/useWarpRouteVisualization.ts
@@ -5,7 +5,18 @@ import { useMemo } from 'react';
 import { useStore } from '../../../store';
 import { WarpRouteDetails } from '../../../types';
 import { normalizeAddressToHex } from '../../../utils/yamlParsing';
-import { WarpRouteTokenVisualization, WarpRouteVisualization } from './types';
+import { TokenConnectionRef, WarpRouteTokenVisualization, WarpRouteVisualization } from './types';
+
+// Token connection refs are formatted `protocol|chainName|addressOrDenom`.
+// Same regex as the SDK's TokenConnectionRegex but we only need a parser here.
+const TOKEN_CONNECTION_REGEX = /^([^|]+)\|([^|]+)\|(.+)$/;
+
+function parseTokenConnection(raw: string): TokenConnectionRef | undefined {
+  const match = TOKEN_CONNECTION_REGEX.exec(raw);
+  if (!match) return undefined;
+  const [, protocol, chainName, addressOrDenom] = match;
+  return { raw, protocol, chainName, addressOrDenom };
+}
 
 /**
  * Find the warp route config that contains the given token address on the given chain
@@ -57,6 +68,10 @@ export function useWarpRouteVisualization(warpRouteDetails: WarpRouteDetails | u
       decimals: token.decimals ?? 18,
       standard: token.standard,
       logoURI: token.logoURI,
+      collateralAddressOrDenom: token.collateralAddressOrDenom,
+      enrollments: token.connections
+        ?.map((c) => parseTokenConnection(c.token))
+        .filter((c): c is TokenConnectionRef => c !== undefined),
     }));
 
     return {


### PR DESCRIPTION
## Summary

- Parse each token's `connections` field (`protocol|chainName|address` refs) and `collateralAddressOrDenom` from the registry config into a typed `enrollments` list on `WarpRouteTokenVisualization`. The new field is named `enrollments` rather than `connections` to avoid colliding with the SDK's `HypTokenAdapterInput.connections` shape.
- Add `CrossCollateralEnrollments` — a new card section that lists each token in the route alongside its sub-route enrollments (chain · symbol · short address) and its collateral asset.
- Render the section under the existing graph in `WarpRouteVisualizationCard` whenever any token in the route uses a cross-collateral standard (`EvmHypCrossCollateralRouter`, `SealevelHypCrossCollateral`, `TronHypCrossCollateralRouter`).

## Why

The Warp Route Overview graph renders every token in a warp route as a flat list. For cross-collateral routers — where each token holds a distinct collateral asset and enrolls with its own subset of remote tokens — that flat list hides the sub-route structure entirely. Reported on cross-collateral message [`0xb805…2cc3`](https://explorer.hyperlane.xyz/message/0xb805ef31a4e045e9dbb78692ead2942de12544e4d624b3117b0a41f9a3f32cc3) (CROSS/moonpay, USDC ETH → XO Solana).

This uses the registry's `connections` field, which is already loaded client-side, so the new section adds no RPC calls.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] Pre-existing jest failures unchanged
- [ ] Manual: load message `0xb805ef31a4e045e9dbb78692ead2942de12544e4d624b3117b0a41f9a3f32cc3`, expand Warp Route Overview, verify the new "Cross-collateral sub-route enrollments" section lists each token with chain, symbol, collateral asset, and enrollment chips
- [ ] Manual: load a non-cross-collateral warp route message and confirm the section does not render