### PR TITLE
fix(explorer): show Warped Token for CosmosIbc legs (TIA Celestia→Forma)

### DIFF
--- a/src/features/messages/MessageDetailsInner.tsx
+++ b/src/features/messages/MessageDetailsInner.tsx
@@ -76,6 +76,7 @@ export function MessageDetailsInner({ messageId, message: messageFromUrlParams }
   const ensureWarpRouteData = useStore((s) => s.ensureWarpRouteData);
   const isWarpRouteDataLoaded = useStore((s) => s.isWarpRouteDataLoaded);
   const warpRouteChainAddressMap = useStore((s) => s.warpRouteChainAddressMap);
+  const warpRouteIdToAddressesMap = useStore((s) => s.warpRouteIdToAddressesMap);
   const [runtimeState, setRuntimeState] = useState<{
     messageId: string;
     value: MessageDetailsRuntimeState;
@@ -123,8 +124,14 @@ export function MessageDetailsInner({ messageId, message: messageFromUrlParams }
   const destinationChainName =
     chainMetadataResolver.tryGetChainName(destinationDomainId) || 'Unknown';
   const warpRouteDetails = useMemo(
-    () => parseWarpRouteMessageDetails(message, warpRouteChainAddressMap, chainMetadataResolver),
-    [chainMetadataResolver, message, warpRouteChainAddressMap],
+    () =>
+      parseWarpRouteMessageDetails(
+        message,
+        warpRouteChainAddressMap,
+        warpRouteIdToAddressesMap,
+        chainMetadataResolver,
+      ),
+    [chainMetadataResolver, message, warpRouteChainAddressMap, warpRouteIdToAddressesMap],
   );
   const txMessageCount = useTransactionMessageCount(isMessageFound ? origin.hash : undefined);
   const showTxLink = txMessageCount > 1;

--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -1,5 +1,8 @@
 import type { ChainMetadataResolver } from '@hyperlane-xyz/sdk/metadata/ChainMetadataResolver';
-import type { WarpRouteChainAddressMap } from '@hyperlane-xyz/sdk/warp/read';
+import type {
+  WarpRouteChainAddressMap,
+  WarpRouteIdToAddressesMap,
+} from '@hyperlane-xyz/sdk/warp/read';
 import { isNullish, shortenAddress } from '@hyperlane-xyz/utils';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -35,6 +38,7 @@ export function MessageTable({
   const router = useRouter();
   const chainMetadataResolver = useChainMetadataResolver();
   const warpRouteChainAddressMap = useStore((s) => s.warpRouteChainAddressMap);
+  const warpRouteIdToAddressesMap = useStore((s) => s.warpRouteIdToAddressesMap);
   const { scrapedDomains } = useScrapedDomains();
   const backgroundPrefetchKey = useMemo(() => {
     if (isFetching) return '';
@@ -100,6 +104,7 @@ export function MessageTable({
               router={router}
               scrapedChains={scrapedDomains}
               warpRouteChainAddressMap={warpRouteChainAddressMap}
+              warpRouteIdToAddressesMap={warpRouteIdToAddressesMap}
             />
           </tr>
         ))}
@@ -114,12 +119,14 @@ export const MessageSummaryRow = memo(function MessageSummaryRow({
   router,
   scrapedChains,
   warpRouteChainAddressMap,
+  warpRouteIdToAddressesMap,
 }: {
   message: MessageStub;
   chainMetadataResolver: ChainMetadataResolver;
   router: NextRouter;
   scrapedChains: ReturnType<typeof useScrapedDomains>['scrapedDomains'];
   warpRouteChainAddressMap: WarpRouteChainAddressMap;
+  warpRouteIdToAddressesMap: WarpRouteIdToAddressesMap;
 }) {
   const { msgId, status, sender, recipient, originDomainId, destinationDomainId, origin } = message;
 
@@ -165,8 +172,14 @@ export const MessageSummaryRow = memo(function MessageSummaryRow({
   const destinationChainName =
     chainMetadataResolver.tryGetChainName(destinationDomainId) || 'Unknown';
   const warpRouteDetails = useMemo(
-    () => parseWarpRouteMessageDetails(message, warpRouteChainAddressMap, chainMetadataResolver),
-    [message, warpRouteChainAddressMap, chainMetadataResolver],
+    () =>
+      parseWarpRouteMessageDetails(
+        message,
+        warpRouteChainAddressMap,
+        warpRouteIdToAddressesMap,
+        chainMetadataResolver,
+      ),
+    [message, warpRouteChainAddressMap, warpRouteIdToAddressesMap, chainMetadataResolver],
   );
   const isDifferentWarpToken = warpRouteDetails
     ? warpRouteDetails.originToken.symbol !== warpRouteDetails.destinationToken.symbol ||

--- a/src/features/messages/utils.test.ts
+++ b/src/features/messages/utils.test.ts
@@ -1,6 +1,9 @@
 import { type ChainMetadata, TokenStandard } from '@hyperlane-xyz/sdk';
 import type { ChainMetadataResolver } from '@hyperlane-xyz/sdk/metadata/ChainMetadataResolver';
-import type { WarpRouteChainAddressMap } from '@hyperlane-xyz/sdk/warp/read';
+import type {
+  WarpRouteChainAddressMap,
+  WarpRouteIdToAddressesMap,
+} from '@hyperlane-xyz/sdk/warp/read';
 import {
   addressToBytes32,
   bytesToProtocolAddress,
@@ -103,13 +106,23 @@ function buildTestSetup({
     },
   };
 
-  return { message, warpRouteChainAddressMap, chainMetadataResolver };
+  return {
+    message,
+    warpRouteChainAddressMap,
+    warpRouteIdToAddressesMap: {},
+    chainMetadataResolver,
+  };
 }
 
 describe('parseWarpRouteMessageDetails', () => {
   describe('destAmount', () => {
     it('returns null when both tokens have no scale', () => {
-      const { message, warpRouteChainAddressMap, chainMetadataResolver } = buildTestSetup({
+      const {
+        message,
+        warpRouteChainAddressMap,
+        warpRouteIdToAddressesMap,
+        chainMetadataResolver,
+      } = buildTestSetup({
         originToken: { decimals: 18 },
         destToken: { decimals: 18 },
         messageAmount: 10n ** 18n,
@@ -118,6 +131,7 @@ describe('parseWarpRouteMessageDetails', () => {
       const result = parseWarpRouteMessageDetails(
         message,
         warpRouteChainAddressMap,
+        warpRouteIdToAddressesMap,
         chainMetadataResolver,
       );
 
@@ -127,7 +141,12 @@ describe('parseWarpRouteMessageDetails', () => {
 
     it('returns null when scales are equivalent fractions', () => {
       // origin {2,4} and dest {1,2} both normalize to 1/2 — equal
-      const { message, warpRouteChainAddressMap, chainMetadataResolver } = buildTestSetup({
+      const {
+        message,
+        warpRouteChainAddressMap,
+        warpRouteIdToAddressesMap,
+        chainMetadataResolver,
+      } = buildTestSetup({
         originToken: { decimals: 18, scale: { numerator: 2, denominator: 4 } },
         destToken: { decimals: 18, scale: { numerator: 1, denominator: 2 } },
         messageAmount: 10n ** 18n,
@@ -136,6 +155,7 @@ describe('parseWarpRouteMessageDetails', () => {
       const result = parseWarpRouteMessageDetails(
         message,
         warpRouteChainAddressMap,
+        warpRouteIdToAddressesMap,
         chainMetadataResolver,
       );
 
@@ -147,7 +167,12 @@ describe('parseWarpRouteMessageDetails', () => {
       // VRA: origin scale=10, dest scale=1, both 18 decimals.
       // Sending 1 VRA from origin: localAmount=1e18, message=1e18*10=1e19.
       // Dest: localAmount = 1e19 * 1 / 1 = 1e19 → fromWei(1e19, 18) = "10".
-      const { message, warpRouteChainAddressMap, chainMetadataResolver } = buildTestSetup({
+      const {
+        message,
+        warpRouteChainAddressMap,
+        warpRouteIdToAddressesMap,
+        chainMetadataResolver,
+      } = buildTestSetup({
         originToken: { decimals: 18, scale: 10 },
         destToken: { decimals: 18, scale: 1 },
         messageAmount: 10n ** 19n,
@@ -156,6 +181,7 @@ describe('parseWarpRouteMessageDetails', () => {
       const result = parseWarpRouteMessageDetails(
         message,
         warpRouteChainAddressMap,
+        warpRouteIdToAddressesMap,
         chainMetadataResolver,
       );
 
@@ -168,7 +194,12 @@ describe('parseWarpRouteMessageDetails', () => {
       // Origin: 18 dec with scale {1, 1e12} (scale-down). Dest: 6 dec, no scale.
       // Sending 1 USDT from origin: localAmount=1e18, message=1e18*1/1e12=1e6.
       // Dest (no scale): localAmount = 1e6 → fromWei(1e6, 6) = "1".
-      const { message, warpRouteChainAddressMap, chainMetadataResolver } = buildTestSetup({
+      const {
+        message,
+        warpRouteChainAddressMap,
+        warpRouteIdToAddressesMap,
+        chainMetadataResolver,
+      } = buildTestSetup({
         originToken: { decimals: 18, scale: { numerator: 1, denominator: 1_000_000_000_000 } },
         destToken: { decimals: 6 },
         messageAmount: 1_000_000n,
@@ -177,6 +208,7 @@ describe('parseWarpRouteMessageDetails', () => {
       const result = parseWarpRouteMessageDetails(
         message,
         warpRouteChainAddressMap,
+        warpRouteIdToAddressesMap,
         chainMetadataResolver,
       );
 
@@ -264,6 +296,7 @@ describe('parseWarpRouteMessageDetails', () => {
       const result = parseWarpRouteMessageDetails(
         message,
         warpRouteChainAddressMap,
+        {},
         chainMetadataResolver,
       );
 
@@ -349,6 +382,7 @@ describe('parseWarpRouteMessageDetails', () => {
       const result = parseWarpRouteMessageDetails(
         message,
         warpRouteChainAddressMap,
+        {},
         chainMetadataResolver,
       );
 
@@ -362,7 +396,12 @@ describe('parseWarpRouteMessageDetails', () => {
       // Origin: 18 dec, no scale. Dest: 18 dec with scale-down {1, 10}.
       // Sending 1 token from origin: localAmount=1e18, message=1e18 (no scale).
       // Dest: localAmount = 1e18 * 10 / 1 = 1e19 → fromWei(1e19, 18) = "10".
-      const { message, warpRouteChainAddressMap, chainMetadataResolver } = buildTestSetup({
+      const {
+        message,
+        warpRouteChainAddressMap,
+        warpRouteIdToAddressesMap,
+        chainMetadataResolver,
+      } = buildTestSetup({
         originToken: { decimals: 18 },
         destToken: { decimals: 18, scale: { numerator: 1, denominator: 10 } },
         messageAmount: 10n ** 18n,
@@ -371,12 +410,163 @@ describe('parseWarpRouteMessageDetails', () => {
       const result = parseWarpRouteMessageDetails(
         message,
         warpRouteChainAddressMap,
+        warpRouteIdToAddressesMap,
         chainMetadataResolver,
       );
 
       expect(result).toBeDefined();
       expect(result!.amount).toBe('1');
       expect(result!.destAmount).toBe('10');
+    });
+  });
+
+  describe('single-leg match via shared warp route (CosmosIbc)', () => {
+    // TIA Celestia -> Forma. The celestia token is keyed in the registry by its
+    // IBC denom (`utia`), but the on-chain sender is the hyperlane router app
+    // (bytes32 "router_app..."), which never matches the denom. The forma leg
+    // matches by address; the celestia token is then resolved via the route.
+    const CELESTIA_DOMAIN = 1128614981;
+    const FORMA_DOMAIN = 984122;
+    const CELESTIA_ROUTER_BYTES32 =
+      '0x726f757465725f61707000000000000000000000000000010000000000000008';
+    const FORMA_TOKEN = '0x832d26B6904BA7539248Db4D58614251FD63dC05';
+    const END_RECIPIENT = '0x2222222222222222222222222222222222222222';
+    const END_RECIPIENT_BYTES32 = '0x000000000000000000000000' + END_RECIPIENT.slice(2);
+
+    function buildCosmosIbcSetup() {
+      const messageAmount = 10n ** 6n; // 1 TIA at 6 decimals
+      const amountHex = messageAmount.toString(16).padStart(64, '0');
+      const body = '0x' + END_RECIPIENT_BYTES32.slice(2) + amountHex;
+
+      const message: MessageStub = {
+        status: MessageStatus.Delivered,
+        id: 'tia-id',
+        msgId: '0xtia',
+        nonce: 1,
+        sender: CELESTIA_ROUTER_BYTES32,
+        recipient: FORMA_TOKEN,
+        originChainId: CELESTIA_DOMAIN,
+        originDomainId: CELESTIA_DOMAIN,
+        destinationChainId: FORMA_DOMAIN,
+        destinationDomainId: FORMA_DOMAIN,
+        origin: { timestamp: 0, hash: '0x0', from: CELESTIA_ROUTER_BYTES32, to: FORMA_TOKEN },
+        body,
+      };
+
+      const warpRouteChainAddressMap: WarpRouteChainAddressMap = {
+        celestia: {
+          utia: {
+            chainName: 'celestia',
+            standard: TokenStandard.CosmosIbc,
+            addressOrDenom: 'utia',
+            decimals: 6,
+            symbol: 'TIA',
+            name: 'TIA',
+            wireDecimals: 18,
+          },
+        },
+        forma: {
+          [FORMA_TOKEN]: {
+            chainName: 'forma',
+            standard: TokenStandard.EvmNative,
+            addressOrDenom: FORMA_TOKEN,
+            decimals: 18,
+            symbol: 'TIA',
+            name: 'TIA',
+            wireDecimals: 18,
+          },
+        },
+      };
+
+      const celestiaMetadata = {
+        name: 'celestia',
+        chainId: CELESTIA_DOMAIN,
+        domainId: CELESTIA_DOMAIN,
+        protocol: ProtocolType.Cosmos,
+        bech32Prefix: 'celestia',
+      } as ChainMetadata;
+      const formaMetadata = {
+        name: 'forma',
+        chainId: FORMA_DOMAIN,
+        domainId: FORMA_DOMAIN,
+        protocol: ProtocolType.Ethereum,
+      } as ChainMetadata;
+      const chainMetadataResolver: Pick<ChainMetadataResolver, 'tryGetChainMetadata'> = {
+        tryGetChainMetadata: (chain: string | number): ChainMetadata | null => {
+          if (chain === CELESTIA_DOMAIN) return celestiaMetadata;
+          if (chain === FORMA_DOMAIN) return formaMetadata;
+          return null;
+        },
+      };
+
+      return { message, warpRouteChainAddressMap, chainMetadataResolver };
+    }
+
+    it('resolves the celestia token when only the forma leg matches by address', () => {
+      const { message, warpRouteChainAddressMap, chainMetadataResolver } = buildCosmosIbcSetup();
+      const warpRouteIdToAddressesMap: WarpRouteIdToAddressesMap = {
+        'tia/forma-stride': [
+          { chainName: 'celestia', address: 'utia' },
+          { chainName: 'forma', address: FORMA_TOKEN },
+        ],
+      };
+
+      const result = parseWarpRouteMessageDetails(
+        message,
+        warpRouteChainAddressMap,
+        warpRouteIdToAddressesMap,
+        chainMetadataResolver,
+      );
+
+      expect(result).toBeDefined();
+      expect(result!.originToken.symbol).toBe('TIA');
+      expect(result!.originToken.addressOrDenom).toBe('utia');
+      expect(result!.destinationToken.addressOrDenom).toBe(FORMA_TOKEN);
+      expect(result!.amount).toBe('1');
+    });
+
+    it('does not resolve when the route does not cover the other chain', () => {
+      const { message, warpRouteChainAddressMap, chainMetadataResolver } = buildCosmosIbcSetup();
+      // Route contains the matched forma leg but not celestia — wrong transfer.
+      const warpRouteIdToAddressesMap: WarpRouteIdToAddressesMap = {
+        'tia/forma-stride': [
+          { chainName: 'stride', address: 'stride1xyz' },
+          { chainName: 'forma', address: FORMA_TOKEN },
+        ],
+      };
+
+      const result = parseWarpRouteMessageDetails(
+        message,
+        warpRouteChainAddressMap,
+        warpRouteIdToAddressesMap,
+        chainMetadataResolver,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('does not resolve when the matched leg belongs to multiple routes with different counterparts', () => {
+      const { message, warpRouteChainAddressMap, chainMetadataResolver } = buildCosmosIbcSetup();
+      // Shared-collateral ambiguity: same forma token, two celestia counterparts.
+      const warpRouteIdToAddressesMap: WarpRouteIdToAddressesMap = {
+        'tia/forma-stride': [
+          { chainName: 'celestia', address: 'utia' },
+          { chainName: 'forma', address: FORMA_TOKEN },
+        ],
+        'tia/forma-other': [
+          { chainName: 'celestia', address: 'uother' },
+          { chainName: 'forma', address: FORMA_TOKEN },
+        ],
+      };
+
+      const result = parseWarpRouteMessageDetails(
+        message,
+        warpRouteChainAddressMap,
+        warpRouteIdToAddressesMap,
+        chainMetadataResolver,
+      );
+
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/src/features/messages/utils.ts
+++ b/src/features/messages/utils.ts
@@ -1,6 +1,9 @@
 import { scalesEqual } from '@hyperlane-xyz/sdk';
 import type { ChainMetadataResolver } from '@hyperlane-xyz/sdk/metadata/ChainMetadataResolver';
-import type { WarpRouteChainAddressMap } from '@hyperlane-xyz/sdk/warp/read';
+import type {
+  WarpRouteChainAddressMap,
+  WarpRouteIdToAddressesMap,
+} from '@hyperlane-xyz/sdk/warp/read';
 import {
   bytesToProtocolAddress,
   fromBase64,
@@ -13,7 +16,10 @@ import {
 import { Message, MessageStub, WarpRouteDetails } from '../../types';
 import { formatAddress } from '../../utils/addresses';
 import { logger } from '../../utils/logger';
-import { getTokenFromWarpRouteChainAddressMap } from '../../utils/token';
+import {
+  getCounterpartTokenFromWarpRoute,
+  getTokenFromWarpRouteChainAddressMap,
+} from '../../utils/token';
 import { getWarpRouteAmountParts } from '../../utils/warpRouteAmounts';
 
 export function serializeMessage(msg: MessageStub | Message): string | undefined {
@@ -27,6 +33,7 @@ export function deserializeMessage<M extends MessageStub>(data: string | string[
 export function parseWarpRouteMessageDetails(
   message: Message | MessageStub,
   warpRouteChainAddressMap: WarpRouteChainAddressMap,
+  warpRouteIdToAddressesMap: WarpRouteIdToAddressesMap,
   chainMetadataResolver: Pick<ChainMetadataResolver, 'tryGetChainMetadata'>,
 ): WarpRouteDetails | undefined {
   try {
@@ -40,16 +47,38 @@ export function parseWarpRouteMessageDetails(
     const parsedSender = formatAddress(sender, originDomainId, chainMetadataResolver);
     const parsedRecipient = formatAddress(recipient, destinationDomainId, chainMetadataResolver);
 
-    const originToken = getTokenFromWarpRouteChainAddressMap(
+    let originToken = getTokenFromWarpRouteChainAddressMap(
       originMetadata,
       parsedSender,
       warpRouteChainAddressMap,
     );
-    const destinationToken = getTokenFromWarpRouteChainAddressMap(
+    let destinationToken = getTokenFromWarpRouteChainAddressMap(
       destinationMetadata,
       parsedRecipient,
       warpRouteChainAddressMap,
     );
+
+    // Some legs cannot be matched by their on-chain address (e.g. CosmosIbc /
+    // ibc-hyperlane routes, whose on-chain party is the router app rather than
+    // the registry denom key). When exactly one leg matches by address, derive
+    // its counterpart via the shared warp route so the transfer still resolves.
+    if (originToken && !destinationToken) {
+      destinationToken = getCounterpartTokenFromWarpRoute(
+        originMetadata.name,
+        originToken.addressOrDenom,
+        destinationMetadata.name,
+        warpRouteChainAddressMap,
+        warpRouteIdToAddressesMap,
+      );
+    } else if (!originToken && destinationToken) {
+      originToken = getCounterpartTokenFromWarpRoute(
+        destinationMetadata.name,
+        destinationToken.addressOrDenom,
+        originMetadata.name,
+        warpRouteChainAddressMap,
+        warpRouteIdToAddressesMap,
+      );
+    }
 
     // If tokens are not found with the addresses, it means the message
     // is not a warp transfer between tokens known to the registry

--- a/src/features/transactions/MessageSummaryRow.tsx
+++ b/src/features/transactions/MessageSummaryRow.tsx
@@ -33,14 +33,21 @@ export function MessageSummaryRow({ message, index, forceExpanded }: Props) {
 
   const chainMetadataResolver = useChainMetadataResolver();
   const warpRouteChainAddressMap = useStore((s) => s.warpRouteChainAddressMap);
+  const warpRouteIdToAddressesMap = useStore((s) => s.warpRouteIdToAddressesMap);
 
   // Use message data directly from GraphQL - no additional RPC calls for performance
   const { status, originDomainId, destinationDomainId, destination } = message;
 
   // Parse warp route details
   const warpRouteDetails = useMemo(
-    () => parseWarpRouteMessageDetails(message, warpRouteChainAddressMap, chainMetadataResolver),
-    [message, warpRouteChainAddressMap, chainMetadataResolver],
+    () =>
+      parseWarpRouteMessageDetails(
+        message,
+        warpRouteChainAddressMap,
+        warpRouteIdToAddressesMap,
+        chainMetadataResolver,
+      ),
+    [message, warpRouteChainAddressMap, warpRouteIdToAddressesMap, chainMetadataResolver],
   );
 
   const originChainName = chainMetadataResolver.tryGetChainName(originDomainId) || 'Unknown';

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,5 +1,9 @@
 import type { ChainMetadata } from '@hyperlane-xyz/sdk';
-import type { WarpRouteChainAddressMap } from '@hyperlane-xyz/sdk/warp/read';
+import type {
+  TokenArgsWithWireDecimals,
+  WarpRouteChainAddressMap,
+  WarpRouteIdToAddressesMap,
+} from '@hyperlane-xyz/sdk/warp/read';
 import { addressToBytes32, isAddressEvm, objKeys, ProtocolType } from '@hyperlane-xyz/utils';
 
 // Normalize an address to lowercase bytes32 hex so registry keys and
@@ -45,4 +49,48 @@ export function getTokenFromWarpRouteChainAddressMap(
   }
 
   return undefined;
+}
+
+// Resolve the token on `otherChainName` that shares a warp route with an
+// already-matched token (`matchedChainName` + `matchedAddressOrDenom`).
+//
+// Some legs cannot be matched by their on-chain sender/recipient address: for
+// CosmosIbc / ibc-hyperlane routes the on-chain party is the hyperlane router
+// app, which is unrelated to the registry key (an IBC denom such as `utia`).
+// When the opposite leg matches by address we can still attribute the token by
+// walking the route index from the matched leg to its counterpart.
+//
+// A single addressOrDenom can belong to multiple warp routes (shared
+// collateral). To avoid mis-attribution we only resolve when exactly one route
+// contains the matched leg AND covers both chains; otherwise we return
+// undefined so callers fall back to rendering nothing.
+export function getCounterpartTokenFromWarpRoute(
+  matchedChainName: string,
+  matchedAddressOrDenom: string,
+  otherChainName: string,
+  warpRouteChainAddressMap: WarpRouteChainAddressMap,
+  warpRouteIdToAddressesMap: WarpRouteIdToAddressesMap,
+): TokenArgsWithWireDecimals | undefined {
+  const candidateOtherAddresses = new Set<string>();
+
+  for (const tokens of Object.values(warpRouteIdToAddressesMap)) {
+    const hasMatchedLeg = tokens.some(
+      (t) => t.chainName === matchedChainName && t.address === matchedAddressOrDenom,
+    );
+    if (!hasMatchedLeg) continue;
+
+    const otherLegs = tokens.filter((t) => t.chainName === otherChainName);
+    // Disambiguate by requiring the route to cover both chains. A route that
+    // contains the matched leg but not the other chain is the wrong transfer.
+    if (otherLegs.length === 0) continue;
+
+    for (const leg of otherLegs) candidateOtherAddresses.add(leg.address);
+  }
+
+  // 0 routes: not a known warp transfer. >1 distinct counterpart tokens:
+  // ambiguous (shared collateral across routes), do not guess.
+  if (candidateOtherAddresses.size !== 1) return undefined;
+
+  const [otherAddress] = [...candidateOtherAddresses];
+  return warpRouteChainAddressMap[otherChainName]?.[otherAddress];
 }


### PR DESCRIPTION
## Root cause

Celestia→Forma TIA transfers rendered with a blank **Warped Token** column. `parseWarpRouteMessageDetails` (`src/features/messages/utils.ts`) required **both** the origin and destination legs to resolve to a registry token by address (`getTokenFromWarpRouteChainAddressMap`, `src/utils/token.ts`).

For the celestia leg the registry token is keyed by its IBC denom `utia` (standard `CosmosIbc`, route `TIA/forma-stride-config.yaml`). But the on-chain `sender` is the Cosmos **hyperlane router app** address (bytes32 `0x726f757465725f617070…0008`, ASCII "router_app"), which has no relationship to the denom key:

- `formatAddress` returns the Cosmos address unchanged.
- `addressToBytes32("utia", Cosmos)` throws (not bech32), so the denom key can't be canonicalized.
- The `endsWith` fallback (`"utia".endsWith("0x726f…0008")`) is false.

So the origin token never resolves → both-legs requirement fails → `undefined` → blank cell. The Forma EVM leg (`0x832d26B6904BA7539248Db4D58614251FD63dC05`, `EvmNative`) matches fine.

## Change

When **exactly one** leg matches by address, derive the counterpart token via the shared warp route instead of requiring both legs to match by address:

- New `getCounterpartTokenFromWarpRoute` (`src/utils/token.ts`) walks `warpRouteIdToAddressesMap` (already built in the store by the SDK's `buildWarpRouteMaps`) from the matched leg's `{chainName, addressOrDenom}` to the token on the other chain, then looks up its metadata in `warpRouteChainAddressMap`.
- `parseWarpRouteMessageDetails` gains a `warpRouteIdToAddressesMap` parameter and invokes the counterpart lookup only when one leg is missing. The existing both-legs-match fast path is unchanged, so EVM↔EVM routes do not regress.
- Threaded the route-id map through the three call sites (`MessageTable`, `MessageDetailsInner`, transactions `MessageSummaryRow`) from the Zustand store.

## Side effects

- **Mis-attribution risk (shared collateral):** a single `addressOrDenom` can belong to multiple warp routes (reused collateral). To avoid attributing the wrong token/amount, counterpart resolution only succeeds when **exactly one** route both contains the matched leg **and** covers the other chain. The route must cover both the origin and destination chains (disambiguation by domain). If 0 or >1 candidate counterpart tokens result, we return `undefined` and render nothing — same as before. Covered by two negative unit tests (route missing the other chain; shared-collateral ambiguity).
- **Still unmatched:** transfers where **neither** leg matches by address (e.g. Cosmos→Cosmos where both legs are denom-keyed router transfers) remain blank — this PR only rescues the case where one leg is address-matchable. No behavior change for those.
- No change to fetching/indexing; messages already appear in the list, only the column was blank.

## Tests

- `src/features/messages/utils.test.ts`: new describe block for the TIA Celestia→Forma case (origin sender = router-app bytes32, dest recipient = `0x832d…dC05`) plus the two ambiguity guards. Existing tests updated for the new parameter.
- `pnpm typecheck`, `oxlint`, `oxfmt`, and the warp/token jest suites pass (12/12). Two unrelated suites (`scheduleWhenIdle`, `fetchPiChainMessages`) fail identically on `main` — pre-existing, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)