### PR TITLE
feat(messages): warp fee for same-chain CCR swaps + chain-scoped route filter

### DIFF
--- a/src/features/messages/cards/WarpTransferDetailsCard.tsx
+++ b/src/features/messages/cards/WarpTransferDetailsCard.tsx
@@ -140,7 +140,9 @@ export function WarpTransferDetailsCard({ message, warpRouteDetails, blur }: Pro
                 <KeyValueRow
                   label="Warp fee:"
                   labelWidth={styles.labelWidthMd}
-                  display={`${warpFees.bridgeFee} ${warpFees.tokenSymbol}`}
+                  display={`${warpFees.bridgeFee} ${warpFees.tokenSymbol}${
+                    warpFees.bridgeFeeBps ? ` (${warpFees.bridgeFeeBps} bps)` : ''
+                  }`}
                   blurValue={blur}
                 />
               </>

--- a/src/features/messages/queries/useMessageQuery.test.ts
+++ b/src/features/messages/queries/useMessageQuery.test.ts
@@ -1,0 +1,72 @@
+import { MessageStatus, MessageStub } from '../../../types';
+import { messageMatchesWarpRoute } from './useMessageQuery';
+
+const ORIGIN_DOMAIN = 1;
+const DEST_DOMAIN = 10;
+const ROUTER_A = '0x' + '11'.repeat(20);
+const ROUTER_B = '0x' + '22'.repeat(20);
+const OTHER = '0x' + '33'.repeat(20);
+
+function makeStub(overrides: Partial<MessageStub> = {}): MessageStub {
+  return {
+    status: MessageStatus.Delivered,
+    id: 'db-id',
+    msgId: '0x' + 'ab'.repeat(32),
+    nonce: 0,
+    sender: ROUTER_A,
+    recipient: ROUTER_B,
+    originChainId: 1,
+    originDomainId: ORIGIN_DOMAIN,
+    destinationChainId: 10,
+    destinationDomainId: DEST_DOMAIN,
+    origin: { hash: '0x' + '00'.repeat(32), from: OTHER, to: ROUTER_A, timestamp: 0 },
+    body: '0x',
+    ...overrides,
+  };
+}
+
+describe('messageMatchesWarpRoute', () => {
+  it('matches when sender equals route address on the origin domain', () => {
+    const message = makeStub({ sender: ROUTER_A, recipient: OTHER });
+    expect(messageMatchesWarpRoute(message, [{ domainId: ORIGIN_DOMAIN, address: ROUTER_A }])).toBe(
+      true,
+    );
+  });
+
+  it('matches when recipient equals route address on the destination domain', () => {
+    const message = makeStub({ sender: OTHER, recipient: ROUTER_B });
+    expect(messageMatchesWarpRoute(message, [{ domainId: DEST_DOMAIN, address: ROUTER_B }])).toBe(
+      true,
+    );
+  });
+
+  it('matches case-insensitively (checksummed vs lowercase)', () => {
+    const message = makeStub({ sender: ROUTER_A.toUpperCase().replace('0X', '0x') });
+    expect(messageMatchesWarpRoute(message, [{ domainId: ORIGIN_DOMAIN, address: ROUTER_A }])).toBe(
+      true,
+    );
+  });
+
+  it('excludes a route whose address matches but on the wrong chain', () => {
+    // The DB filter matches on address bytes alone, so a route address that
+    // coincides on another domain would leak in without the domain guard.
+    const message = makeStub({ sender: ROUTER_A, recipient: OTHER });
+    expect(messageMatchesWarpRoute(message, [{ domainId: DEST_DOMAIN, address: ROUTER_A }])).toBe(
+      false,
+    );
+  });
+
+  it('returns false when neither sender nor recipient matches', () => {
+    const message = makeStub({ sender: OTHER, recipient: OTHER });
+    expect(
+      messageMatchesWarpRoute(message, [
+        { domainId: ORIGIN_DOMAIN, address: ROUTER_A },
+        { domainId: DEST_DOMAIN, address: ROUTER_B },
+      ]),
+    ).toBe(false);
+  });
+
+  it('returns false for an empty route list', () => {
+    expect(messageMatchesWarpRoute(makeStub(), [])).toBe(false);
+  });
+});

--- a/src/features/messages/queries/useMessageQuery.test.ts
+++ b/src/features/messages/queries/useMessageQuery.test.ts
@@ -6,6 +6,9 @@ const DEST_DOMAIN = 10;
 const ROUTER_A = '0x' + '11'.repeat(20);
 const ROUTER_B = '0x' + '22'.repeat(20);
 const OTHER = '0x' + '33'.repeat(20);
+// Alpha hex digits so upper/lower casing actually differ — needed to exercise
+// case-insensitive address comparison.
+const ROUTER_MIXED = '0x' + 'ab'.repeat(20);
 
 function makeStub(overrides: Partial<MessageStub> = {}): MessageStub {
   return {
@@ -40,11 +43,11 @@ describe('messageMatchesWarpRoute', () => {
     );
   });
 
-  it('matches case-insensitively (checksummed vs lowercase)', () => {
-    const message = makeStub({ sender: ROUTER_A.toUpperCase().replace('0X', '0x') });
-    expect(messageMatchesWarpRoute(message, [{ domainId: ORIGIN_DOMAIN, address: ROUTER_A }])).toBe(
-      true,
-    );
+  it('matches case-insensitively (uppercase sender vs lowercase route address)', () => {
+    const message = makeStub({ sender: '0x' + 'AB'.repeat(20) });
+    expect(
+      messageMatchesWarpRoute(message, [{ domainId: ORIGIN_DOMAIN, address: ROUTER_MIXED }]),
+    ).toBe(true);
   });
 
   it('excludes a route whose address matches but on the wrong chain', () => {

--- a/src/features/messages/queries/useMessageQuery.ts
+++ b/src/features/messages/queries/useMessageQuery.ts
@@ -1,8 +1,9 @@
+import { eqAddress } from '@hyperlane-xyz/utils';
 import { useCallback, useMemo } from 'react';
 import { useQuery } from 'urql';
 
 import { useChainMetadataResolver } from '../../../metadataStore';
-import { MessageStatus, MessageStatusFilter } from '../../../types';
+import { MessageStatus, MessageStatusFilter, MessageStub } from '../../../types';
 import { useVisibleInterval } from '../../../utils/useVisibleInterval';
 import { useScrapedChains, useScrapedDomains } from '../../chains/queries/useScrapedChains';
 import { MessageIdentifierType, buildMessageQuery, buildMessageSearchQuery } from './build';
@@ -22,6 +23,20 @@ const PENDING_FILTER_BATCH_SIZE = 500;
 export function isValidSearchQuery(input: string) {
   if (!input) return false;
   return !!searchValueToPostgresBytea(input);
+}
+
+// A message belongs to the warp route if it was sent from the route's token on
+// the origin chain or received by it on the destination chain. eqAddress is
+// protocol-aware so this stays correct across EVM/Sealevel/Cosmos/etc.
+function messageMatchesWarpRoute(
+  message: MessageStub,
+  warpRouteDomainAddresses: Array<{ domainId: number; address: string }>,
+): boolean {
+  return warpRouteDomainAddresses.some(
+    ({ domainId, address }) =>
+      (message.originDomainId === domainId && eqAddress(message.sender, address)) ||
+      (message.destinationDomainId === domainId && eqAddress(message.recipient, address)),
+  );
 }
 
 export function useMessageSearchQuery(
@@ -56,6 +71,23 @@ export function useMessageSearchQuery(
   const isValidDestination = !destinationChainNameFilter || destDomainId !== null;
 
   const warpAddresses = warpRouteAddresses.map((a) => a.address);
+
+  // Resolve each warp route token to its domain for client-side filtering.
+  // The DB filter matches on address bytes alone (sender OR recipient), so a
+  // route whose address coincides with another route's address on a different
+  // chain leaks in (e.g. BLEND messages showing up under CROSS/moonpay).
+  // Addresses are not guaranteed unique across chains, so we additionally
+  // require the matched address to be on its expected chain.
+  const warpRouteDomainAddresses = useMemo(
+    () =>
+      warpRouteAddresses
+        .map(({ chainName, address }) => ({
+          domainId: chainMetadataResolver.tryGetDomainId(chainName),
+          address,
+        }))
+        .filter((entry): entry is { domainId: number; address: string } => entry.domainId !== null),
+    [warpRouteAddresses, chainMetadataResolver],
+  );
 
   // For pending filter, we use client-side filtering because the DB query for
   // is_delivered=false is slow (no index on absence of delivered_message record).
@@ -95,13 +127,20 @@ export function useMessageSearchQuery(
     [chainMetadataResolver, scrapedChains, data],
   );
 
-  // Apply client-side pending filter if needed
+  // Apply client-side filters. Note: these run after the DB LIMIT, so they
+  // can shrink a page below the requested size — acceptable here since the
+  // alternative (per-chain DB clauses) bloats the query and the pending
+  // filter already relies on client-side narrowing.
   const messageList = useMemo(() => {
+    let list = unfilteredMessageList;
     if (isPendingFilter) {
-      return unfilteredMessageList.filter((m) => m.status === MessageStatus.Pending);
+      list = list.filter((m) => m.status === MessageStatus.Pending);
     }
-    return unfilteredMessageList;
-  }, [unfilteredMessageList, isPendingFilter]);
+    if (warpRouteDomainAddresses.length > 0) {
+      list = list.filter((m) => messageMatchesWarpRoute(m, warpRouteDomainAddresses));
+    }
+    return list;
+  }, [unfilteredMessageList, isPendingFilter, warpRouteDomainAddresses]);
 
   const isMessagesFound = messageList.length > 0;
 

--- a/src/features/messages/queries/useMessageQuery.ts
+++ b/src/features/messages/queries/useMessageQuery.ts
@@ -4,6 +4,7 @@ import { useQuery } from 'urql';
 
 import { useChainMetadataResolver } from '../../../metadataStore';
 import { MessageStatus, MessageStatusFilter, MessageStub } from '../../../types';
+import { logger } from '../../../utils/logger';
 import { useVisibleInterval } from '../../../utils/useVisibleInterval';
 import { useScrapedChains, useScrapedDomains } from '../../chains/queries/useScrapedChains';
 import { MessageIdentifierType, buildMessageQuery, buildMessageSearchQuery } from './build';
@@ -28,7 +29,7 @@ export function isValidSearchQuery(input: string) {
 // A message belongs to the warp route if it was sent from the route's token on
 // the origin chain or received by it on the destination chain. eqAddress is
 // protocol-aware so this stays correct across EVM/Sealevel/Cosmos/etc.
-function messageMatchesWarpRoute(
+export function messageMatchesWarpRoute(
   message: MessageStub,
   warpRouteDomainAddresses: Array<{ domainId: number; address: string }>,
 ): boolean {
@@ -85,7 +86,18 @@ export function useMessageSearchQuery(
           domainId: chainMetadataResolver.tryGetDomainId(chainName),
           address,
         }))
-        .filter((entry): entry is { domainId: number; address: string } => entry.domainId !== null),
+        .filter((entry): entry is { domainId: number; address: string } => {
+          if (entry.domainId === null) {
+            // Drop unresolved chains loudly rather than silently widening the
+            // filter — an empty domain list would skip filtering entirely and
+            // leak unrelated messages (the very bug client-side filtering fixes).
+            logger.warn('Could not resolve domainId for warp route chain, dropping from filter', {
+              address: entry.address,
+            });
+            return false;
+          }
+          return true;
+        }),
     [warpRouteAddresses, chainMetadataResolver],
   );
 

--- a/src/features/messages/warpFees/fetchWarpFees.test.ts
+++ b/src/features/messages/warpFees/fetchWarpFees.test.ts
@@ -1,8 +1,12 @@
 import { BigNumber, utils } from 'ethers';
 
+import type { MessageStub } from '../../../types';
 import {
+  countReceivedTransferRemotes,
+  isSyntheticSameChainCcrMessage,
   parseIgpPaymentForMessage,
   parseSentTransferRemoteAmount,
+  parseSwapAmountFromBody,
   parseTotalTokenPulledFromUser,
   sliceLogsForMessage,
 } from './fetchWarpFees';
@@ -14,6 +18,9 @@ const routerIface = new utils.Interface([
   'event SentTransferRemote(uint32 indexed destination, bytes32 indexed recipient, uint256 amountOrId)',
 ]);
 const mailboxIface = new utils.Interface(['event DispatchId(bytes32 indexed messageId)']);
+const receivedIface = new utils.Interface([
+  'event ReceivedTransferRemote(uint32 indexed origin, bytes32 indexed recipient, uint256 amount)',
+]);
 const igpIface = new utils.Interface([
   'event GasPayment(bytes32 indexed messageId, uint32 indexed destinationDomain, uint256 gasAmount, uint256 payment)',
 ]);
@@ -40,6 +47,20 @@ function makeSentTransferRemoteLog(
 function makeDispatchIdLog(messageId: string, mailboxAddress: string) {
   const log = mailboxIface.encodeEventLog(mailboxIface.getEvent('DispatchId'), [messageId]);
   return { ...log, address: mailboxAddress };
+}
+
+function makeReceivedTransferRemoteLog(
+  origin: number,
+  recipient: string,
+  amount: BigNumber,
+  address: string,
+) {
+  const log = receivedIface.encodeEventLog(receivedIface.getEvent('ReceivedTransferRemote'), [
+    origin,
+    recipient,
+    amount,
+  ]);
+  return { ...log, address };
 }
 
 function makeGasPaymentLog(
@@ -268,5 +289,67 @@ describe('parseIgpPaymentForMessage', () => {
     ];
     const result = parseIgpPaymentForMessage(logs, MSG_ID_1);
     expect(result?.eq(BigNumber.from(150))).toBe(true);
+  });
+});
+
+// Synthetic msgId: 4-byte zero prefix + 28 bytes, per syntheticCcrSwapMessageId.
+const SYNTHETIC_MSG_ID = '0x00000000' + 'ab'.repeat(28);
+
+function makeStub(overrides: Partial<MessageStub>): MessageStub {
+  return {
+    msgId: MSG_ID_1,
+    originDomainId: 1,
+    destinationDomainId: 2,
+    sender: SENDER,
+    recipient: RECIPIENT,
+    body: '0x',
+    ...overrides,
+  } as MessageStub;
+}
+
+describe('isSyntheticSameChainCcrMessage', () => {
+  it('is true for same-domain message with zero-prefixed msgId', () => {
+    const m = makeStub({ originDomainId: 1, destinationDomainId: 1, msgId: SYNTHETIC_MSG_ID });
+    expect(isSyntheticSameChainCcrMessage(m)).toBe(true);
+  });
+
+  it('is false for a real (non-prefixed) same-domain msgId', () => {
+    const m = makeStub({ originDomainId: 1, destinationDomainId: 1, msgId: MSG_ID_1 });
+    expect(isSyntheticSameChainCcrMessage(m)).toBe(false);
+  });
+
+  it('is false when origin and destination domains differ', () => {
+    const m = makeStub({ originDomainId: 1, destinationDomainId: 2, msgId: SYNTHETIC_MSG_ID });
+    expect(isSyntheticSameChainCcrMessage(m)).toBe(false);
+  });
+});
+
+describe('parseSwapAmountFromBody', () => {
+  it('reads the wire amount from a TokenMessage body', () => {
+    const amount = BigNumber.from('995000');
+    // TokenMessage = recipient (32 bytes) || amount (32 bytes)
+    const body = '0x' + RECIPIENT.slice(2) + utils.hexZeroPad(amount.toHexString(), 32).slice(2);
+    const result = parseSwapAmountFromBody(body);
+    expect(result?.eq(amount)).toBe(true);
+  });
+
+  it('returns null for an unparseable body', () => {
+    expect(parseSwapAmountFromBody('0x')).toBeNull();
+  });
+});
+
+describe('countReceivedTransferRemotes', () => {
+  it('counts ReceivedTransferRemote events', () => {
+    const logs = [
+      makeReceivedTransferRemoteLog(1, RECIPIENT, BigNumber.from(100), ROUTER),
+      makeTransferLog(SENDER, ROUTER, BigNumber.from(100), TOKEN),
+      makeReceivedTransferRemoteLog(1, RECIPIENT, BigNumber.from(200), ROUTER),
+    ];
+    expect(countReceivedTransferRemotes(logs)).toBe(2);
+  });
+
+  it('returns 0 when there are none', () => {
+    const logs = [makeTransferLog(SENDER, ROUTER, BigNumber.from(100), TOKEN)];
+    expect(countReceivedTransferRemotes(logs)).toBe(0);
   });
 });

--- a/src/features/messages/warpFees/fetchWarpFees.test.ts
+++ b/src/features/messages/warpFees/fetchWarpFees.test.ts
@@ -2,6 +2,7 @@ import { BigNumber, utils } from 'ethers';
 
 import type { MessageStub } from '../../../types';
 import {
+  computeFeeBps,
   countReceivedTransferRemotes,
   isSyntheticSameChainCcrMessage,
   parseIgpPaymentForMessage,
@@ -351,5 +352,29 @@ describe('countReceivedTransferRemotes', () => {
   it('returns 0 when there are none', () => {
     const logs = [makeTransferLog(SENDER, ROUTER, BigNumber.from(100), TOKEN)];
     expect(countReceivedTransferRemotes(logs)).toBe(0);
+  });
+});
+
+describe('computeFeeBps', () => {
+  it('computes whole bps (fee 300000 on 1e9 = 3 bps)', () => {
+    expect(computeFeeBps(BigNumber.from(300000), BigNumber.from('1000000000'))).toBe('3');
+  });
+
+  it('computes 2 bps', () => {
+    expect(computeFeeBps(BigNumber.from(200000), BigNumber.from('1000000000'))).toBe('2');
+  });
+
+  it('keeps 2 decimal places for near-bps amounts', () => {
+    // 1999999 / 1e9 = 19.99999 bps -> truncated to 19.99
+    expect(computeFeeBps(BigNumber.from(1999999), BigNumber.from('1000000000'))).toBe('19.99');
+  });
+
+  it('returns undefined when sent amount is zero', () => {
+    expect(computeFeeBps(BigNumber.from(100), BigNumber.from(0))).toBeUndefined();
+  });
+
+  it('returns undefined when the rate rounds below 0.01 bps', () => {
+    // 1 wei fee on 1e9 -> 0.00001 bps -> rounds to 0
+    expect(computeFeeBps(BigNumber.from(1), BigNumber.from('1000000000'))).toBeUndefined();
   });
 });

--- a/src/features/messages/warpFees/fetchWarpFees.test.ts
+++ b/src/features/messages/warpFees/fetchWarpFees.test.ts
@@ -377,4 +377,16 @@ describe('computeFeeBps', () => {
     // 1 wei fee on 1e9 -> 0.00001 bps -> rounds to 0
     expect(computeFeeBps(BigNumber.from(1), BigNumber.from('1000000000'))).toBeUndefined();
   });
+
+  it('does not throw when fee*1e6 exceeds Number.MAX_SAFE_INTEGER', () => {
+    // 1e18 fee on 1e21 -> fee*1e6 = 1e24, far past 2^53. Must stay in BigNumber
+    // land; a `.toNumber()` here would throw an ethers NUMERIC_FAULT.
+    const fee = BigNumber.from('1000000000000000000'); // 1e18
+    const sent = BigNumber.from('1000000000000000000000'); // 1e21
+    expect(computeFeeBps(fee, sent)).toBe('10');
+  });
+
+  it('trims trailing zero in the fractional part (fee 250000 on 1e9 = 2.5 bps)', () => {
+    expect(computeFeeBps(BigNumber.from(250000), BigNumber.from('1000000000'))).toBe('2.5');
+  });
 });

--- a/src/features/messages/warpFees/fetchWarpFees.ts
+++ b/src/features/messages/warpFees/fetchWarpFees.ts
@@ -5,7 +5,7 @@ import {
   TokenRouter__factory, // eslint-disable-line camelcase
 } from '@hyperlane-xyz/core';
 import { PROTOCOL_TO_HYP_NATIVE_STANDARD } from '@hyperlane-xyz/sdk';
-import { ProtocolType, fromWei, isEVMLike } from '@hyperlane-xyz/utils';
+import { ProtocolType, fromWei, isEVMLike, parseWarpRouteMessage } from '@hyperlane-xyz/utils';
 import { BigNumber, constants } from 'ethers';
 
 import { Message, MessageStub, WarpRouteDetails } from '../../../types';
@@ -50,6 +50,14 @@ const HYP_NATIVE_STANDARDS = new Set<string>(Object.values(PROTOCOL_TO_HYP_NATIV
  * message's `Mailbox.DispatchId`, so multi-send ERC20 txs are attributed
  * correctly. IGP `GasPayment` is correlated by `messageId` directly.
  *
+ * **Same-chain CCR swaps** are a special case: the scraper synthesizes a
+ * message row (origin == destination, `0x00000000…` msgId prefix) for these
+ * because they call `handle()` directly with no Mailbox dispatch — so there's
+ * no `DispatchId` to slice on and no `SentTransferRemote` to read. For these
+ * we read the swap amount from the message body (the on-chain `TokenMessage`)
+ * and scan the full receipt, but only when the tx holds exactly one same-chain
+ * swap and no cross-chain dispatch, so the user-pull sum stays unambiguous.
+ *
  * Supports EVM-like chains (Ethereum + Tron). Non-EVM chains, txs without a
  * matching `DispatchId`, and zero-fee routes return `null`.
  *
@@ -80,10 +88,27 @@ export async function fetchWarpFees(
   if (!receipt) throw new Error(`No receipt for tx ${message.origin.hash}`);
 
   const routerAddress = warpRouteDetails.originToken.addressOrDenom;
-  const messageLogs = sliceLogsForMessage(receipt.logs, message.msgId);
-  if (!messageLogs) return null;
 
-  const sentAmountWire = parseSentTransferRemoteAmount(messageLogs, routerAddress);
+  let messageLogs: RawLog[] | null;
+  let sentAmountWire: BigNumber | null;
+  if (isSyntheticSameChainCcrMessage(message)) {
+    // Same-chain CCR: no DispatchId to slice on and no SentTransferRemote.
+    // Only attribute when the tx holds exactly one same-chain swap (one
+    // ReceivedTransferRemote) and no cross-chain dispatch, so summing the
+    // user's token pull across the full receipt stays unambiguous.
+    if (
+      countReceivedTransferRemotes(receipt.logs) !== 1 ||
+      countSentTransferRemotes(receipt.logs) !== 0
+    ) {
+      return null;
+    }
+    messageLogs = receipt.logs;
+    sentAmountWire = parseSwapAmountFromBody(message.body);
+  } else {
+    messageLogs = sliceLogsForMessage(receipt.logs, message.msgId);
+    if (!messageLogs) return null;
+    sentAmountWire = parseSentTransferRemoteAmount(messageLogs, routerAddress);
+  }
   if (!sentAmountWire) return null;
 
   const sentAmount = sentAmountToLocal(sentAmountWire, warpRouteDetails.originToken);
@@ -154,6 +179,45 @@ function parseDispatchIdLog(log: RawLog): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * True for the synthetic message rows the scraper stores for same-chain CCR
+ * swaps. These have origin == destination and a 4-byte-zero msgId prefix (see
+ * `syntheticCcrSwapMessageId` in @hyperlane-xyz/utils). Real Hyperlane message
+ * IDs are uniform keccak256 outputs, so the zero prefix is unambiguous.
+ */
+export function isSyntheticSameChainCcrMessage(message: Message | MessageStub): boolean {
+  return (
+    message.originDomainId === message.destinationDomainId &&
+    message.msgId.toLowerCase().startsWith('0x00000000')
+  );
+}
+
+/**
+ * Read the wire (scaled) swap amount from the synthetic message body, which is
+ * the on-chain `TokenMessage` the router formatted for the same-chain swap.
+ * The caller reverses the token scale to get the local amount.
+ */
+export function parseSwapAmountFromBody(body: string): BigNumber | null {
+  try {
+    const { amount } = parseWarpRouteMessage(body);
+    return BigNumber.from(amount.toString());
+  } catch {
+    return null;
+  }
+}
+
+export function countReceivedTransferRemotes(logs: Array<RawLog>): number {
+  let count = 0;
+  for (const log of logs) {
+    try {
+      if (routerIface.parseLog(log).name === 'ReceivedTransferRemote') count++;
+    } catch {
+      // not a TokenRouter event
+    }
+  }
+  return count;
 }
 
 /**

--- a/src/features/messages/warpFees/fetchWarpFees.ts
+++ b/src/features/messages/warpFees/fetchWarpFees.ts
@@ -157,10 +157,14 @@ export async function fetchWarpFees(
  */
 export function computeFeeBps(fee: BigNumber, sentAmount: BigNumber): string | undefined {
   if (sentAmount.isZero()) return undefined;
-  // bps × 100 = fee / amount * 10_000 * 100, using integer math for precision.
-  const bpsHundredths = fee.mul(1_000_000).div(sentAmount).toNumber();
-  if (bpsHundredths === 0) return undefined;
-  return (bpsHundredths / 100).toString();
+  // bps × 100 = fee / amount * 10_000 * 100. Stay in BigNumber land: fee and
+  // sentAmount can both exceed Number.MAX_SAFE_INTEGER, so `.toNumber()` would
+  // throw an ethers NUMERIC_FAULT. Format the fixed-point string by hand.
+  const bpsHundredths = fee.mul(1_000_000).div(sentAmount);
+  if (bpsHundredths.isZero()) return undefined;
+  const whole = bpsHundredths.div(100).toString();
+  const fractional = bpsHundredths.mod(100).toString().padStart(2, '0').replace(/0+$/, '');
+  return fractional ? `${whole}.${fractional}` : whole;
 }
 
 /**

--- a/src/features/messages/warpFees/fetchWarpFees.ts
+++ b/src/features/messages/warpFees/fetchWarpFees.ts
@@ -15,6 +15,9 @@ import type { ExplorerMultiProvider } from '../../hyperlane/sdkRuntime';
 
 export interface WarpFeeBreakdown {
   bridgeFee: string;
+  // Fee as a rate of the sent amount, in basis points (e.g. "2"). Omitted when
+  // the sent amount is zero or the fee rounds below 0.01 bps.
+  bridgeFeeBps?: string;
   tokenSymbol: string;
   totalSent: string;
 }
@@ -139,9 +142,25 @@ export async function fetchWarpFees(
     // (e.g. 0.0000015 USDT), so `formatAmountWithCommas`' 6-digit cap would
     // misrepresent the value users are trying to verify against the tx logs.
     bridgeFee: fromWei(feeRaw.toString(), decimals),
+    bridgeFeeBps: computeFeeBps(feeRaw, sentAmount),
     tokenSymbol: symbol ?? 'tokens',
     totalSent: fromWei(totalTransferred.toString(), decimals),
   };
+}
+
+/**
+ * Fee as a rate of the sent amount, in basis points. Matches the on-chain
+ * convention (`fee = amount * maxFee / (2 * halfAmount)`), so the denominator
+ * is the amount the user sent, not the gross amount they paid. Kept to 2
+ * decimal places; returns `undefined` when the amount is zero or the rate
+ * rounds below 0.01 bps.
+ */
+export function computeFeeBps(fee: BigNumber, sentAmount: BigNumber): string | undefined {
+  if (sentAmount.isZero()) return undefined;
+  // bps × 100 = fee / amount * 10_000 * 100, using integer math for precision.
+  const bpsHundredths = fee.mul(1_000_000).div(sentAmount).toNumber();
+  if (bpsHundredths === 0) return undefined;
+  return (bpsHundredths / 100).toString();
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Populate the "Warp fee" line for same-chain CCR swaps.** These swaps call `handle()` directly with no Mailbox dispatch, so they have no `DispatchId`/`SentTransferRemote`. `fetchWarpFees` relied on `DispatchId`-based log slicing and returned `null` for them, leaving the fee blank. Added a synthetic-message branch (detected via `origin == destination` + `0x00000000…` msgId prefix, matching the scraper's `syntheticCcrSwapMessageId`) that reads the swap amount from the message body (the on-chain `TokenMessage`) and scans the full receipt. Gated to txs with exactly one same-chain swap and no cross-chain dispatch so the user-pull sum stays unambiguous. Fee math is otherwise identical to the existing ERC20 path (tokens pulled − swap amount).
- **Show the warp fee rate in bps** in parentheses next to the fee amount (e.g. `0.0000015 USDT (2 bps)`), computed against the sent amount to match the on-chain `fee = amount * maxFee / (2 * halfAmount)` convention.
- **Stop other warp routes leaking into a route's search results.** The DB filter matches on address bytes alone (sender OR recipient), so a route whose token shares an address with another route on a different chain leaked in (e.g. BLEND messages under CROSS/moonpay). Added client-side filtering in `useMessageSearchQuery` that requires the matched address to be on its expected chain, resolving each `{chainName, address}` to a domain and comparing with protocol-aware `eqAddress`.

## Notes
- Client-side filter runs after the DB `LIMIT` (consistent with the existing pending-status filter). This can shrink a page below the requested size; chosen over per-chain DB clauses, which bloat the split query.
- No `@hyperlane-xyz/utils` bump needed — synthetic-id detection is structural, since the installed v33.0.2 predates the `syntheticCcrSwapMessageId` export.

## Review remediation
- `computeFeeBps` stays entirely in BigNumber — the previous `.toNumber()` threw an ethers `NUMERIC_FAULT` for large fee/amount ratios, which would have failed the whole `useWarpFees` query.
- Unresolved warp-route chains are now logged and dropped from the client-side filter rather than silently widening it (which would skip filtering and re-leak unrelated messages).
- `messageMatchesWarpRoute` exported and covered by a dedicated test suite.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 warnings/errors
- [x] `pnpm test -- fetchWarpFees` — 36 passing (incl. `computeFeeBps` whole/fractional/zero/large-ratio cases)
- [x] `pnpm test -- useMessageQuery` — 6 passing (`messageMatchesWarpRoute`: origin/destination match, wrong-chain exclusion, case-insensitive, no-match, empty list)
- [ ] Preview build: verify a same-chain CCR swap message shows a "Warp fee", and that filtering by a CROSS/moonpay route no longer lists BLEND messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)