### PR TITLE
chore: upgrade oxfmt

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -2,7 +2,6 @@
   "singleQuote": true,
   "sortImports": {},
   "sortTailwindcss": {
-    "config": "./tailwind.config.js",
     "functions": ["clsx"]
   },
   "ignorePatterns": ["test/outputs", "public"]

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@urql/core": "^6.0.3",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
-    "oxfmt": "0.42.0",
+    "oxfmt": "0.62.0",
     "oxlint": "1.77.0",
     "postcss": "^8.5.24",
     "tailwindcss": "^4.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,8 +148,8 @@ importers:
         specifier: ^30.4.1
         version: 30.4.1(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@6.0.6)
       oxfmt:
-        specifier: 0.42.0
-        version: 0.42.0
+        specifier: 0.62.0
+        version: 0.62.0
       oxlint:
         specifier: 1.77.0
         version: 1.77.0
@@ -1462,124 +1462,124 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
-  '@oxfmt/binding-android-arm-eabi@0.42.0':
-    resolution: {integrity: sha512-dsqPTYsozeokRjlrt/b4E7Pj0z3eS3Eg74TWQuuKbjY4VttBmA88rB7d50Xrd+TZ986qdXCNeZRPEzZHAe+jow==}
+  '@oxfmt/binding-android-arm-eabi@0.62.0':
+    resolution: {integrity: sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxfmt/binding-android-arm64@0.42.0':
-    resolution: {integrity: sha512-t+aAjHxcr5eOBphFHdg1ouQU9qmZZoRxnX7UOJSaTwSoKsb6TYezNKO0YbWytGXCECObRqNcUxPoPr0KaraAIg==}
+  '@oxfmt/binding-android-arm64@0.62.0':
+    resolution: {integrity: sha512-WC3YQ7uS/KtDrjmqwBviwFKe9qeoi+eXx8aX1z/ffG23Md75myjrJaQqTuJvdOLPoa4EYTjDWH0dHXfwulCVog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxfmt/binding-darwin-arm64@0.42.0':
-    resolution: {integrity: sha512-ulpSEYMKg61C5bRMZinFHrKJYRoKGVbvMEXA5zM1puX3O9T6Q4XXDbft20yrDijpYWeuG59z3Nabt+npeTsM1A==}
+  '@oxfmt/binding-darwin-arm64@0.62.0':
+    resolution: {integrity: sha512-GM8Yf3LjjaR1I8PD0SfeoIlwhsh9GvSF+cQ8sf624Yxnjsyumn95aFzYfKJVefblfDIiOAnZ7QVm2sa21Er/0Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-x64@0.42.0':
-    resolution: {integrity: sha512-ttxLKhQYPdFiM8I/Ri37cvqChE4Xa562nNOsZFcv1CKTVLeEozXjKuYClNvxkXmNlcF55nzM80P+CQkdFBu+uQ==}
+  '@oxfmt/binding-darwin-x64@0.62.0':
+    resolution: {integrity: sha512-d5THp7F8bCxLqNogEXDORRsQD6dosf3EyFtnXfBer6v+8tGdcWIjoDX9WaXrrF/26zOmL8qHpPTKCEvpBDmZkQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxfmt/binding-freebsd-x64@0.42.0':
-    resolution: {integrity: sha512-Og7QS3yI3tdIKYZ58SXik0rADxIk2jmd+/YvuHRyKULWpG4V2fR5V4hvKm624Mc0cQET35waPXiCQWvjQEjwYQ==}
+  '@oxfmt/binding-freebsd-x64@0.62.0':
+    resolution: {integrity: sha512-1DnrtXGZooOZ0fHgAXZUaDQzBVh1CM2MNW4oBXyQ2aWKvCHjyljvT9fgBkOM0fEOb96X5eqtcfJ0YUVt9jj66g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.42.0':
-    resolution: {integrity: sha512-jwLOw/3CW4H6Vxcry4/buQHk7zm9Ne2YsidzTL1kpiMe4qqrRCwev3dkyWe2YkFmP+iZCQ7zku4KwjcLRoh8ew==}
+  '@oxfmt/binding-linux-arm-gnueabihf@0.62.0':
+    resolution: {integrity: sha512-4pQDHOYRH+Huqe0StIaWyvk2CVl/aTaqSrbZpA3/pLS2xH24ME7lBgYprhQF2fRkHBzhGGGKliwxFsDdHwx59g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.42.0':
-    resolution: {integrity: sha512-XwXu2vkMtiq2h7tfvN+WA/9/5/1IoGAVCFPiiQUvcAuG3efR97KNcRGM8BetmbYouFotQ2bDal3yyjUx6IPsTg==}
+  '@oxfmt/binding-linux-arm-musleabihf@0.62.0':
+    resolution: {integrity: sha512-X0jAaZJFMCVKhB6YyWVTQ/wN2DLsBcZKSMqTS76bF6riT+XZdtg2FPEdjDvdVbunO9cG+tWiVaEs4Zs38lxYog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-gnu@0.42.0':
-    resolution: {integrity: sha512-ea7s/XUJoT7ENAtUQDudFe3nkSM3e3Qpz4nJFRdzO2wbgXEcjnchKLEsV3+t4ev3r8nWxIYr9NRjPWtnyIFJVA==}
+  '@oxfmt/binding-linux-arm64-gnu@0.62.0':
+    resolution: {integrity: sha512-682Z8T5s8T5ATArYtsejKvbIfd8LEAXyyDkKkoZVq8HND7Vx8TYLlrDjDSeYfodMeVwHOgkj13lJYR8cj6vUSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-arm64-musl@0.42.0':
-    resolution: {integrity: sha512-+JA0YMlSdDqmacygGi2REp57c3fN+tzARD8nwsukx9pkCHK+6DkbAA9ojS4lNKsiBjIW8WWa0pBrBWhdZEqfuw==}
+  '@oxfmt/binding-linux-arm64-musl@0.62.0':
+    resolution: {integrity: sha512-lk25fAl7KWaLWVJcW0CHEXB7QlQZtx5eDkjpaGMK0hzXTjUe0Wmlu8IKuFHoviSOcEJedRTs4VE/506VqGxGew==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.42.0':
-    resolution: {integrity: sha512-VfnET0j4Y5mdfCzh5gBt0NK28lgn5DKx+8WgSMLYYeSooHhohdbzwAStLki9pNuGy51y4I7IoW8bqwAaCMiJQg==}
+  '@oxfmt/binding-linux-ppc64-gnu@0.62.0':
+    resolution: {integrity: sha512-SFyNqHQLwySceWNLhiSldx7wPXRAzP0L0WcW9GegP3uWrpZGJiZlQO85NbHAFPEfxR9PhZ9qSnZryEh7+v+4Gw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.42.0':
-    resolution: {integrity: sha512-gVlCbmBkB0fxBWbhBj9rcxezPydsQHf4MFKeHoTSPicOQ+8oGeTQgQ8EeesSybWeiFPVRx3bgdt4IJnH6nOjAA==}
+  '@oxfmt/binding-linux-riscv64-gnu@0.62.0':
+    resolution: {integrity: sha512-KYj55C1ywJfHo6+aKDuEmUtVEdJALsC5GwayDGsI6FGz2GxFqNr/mA8nxVsNbJzm7sE5MRqTQ9ziImSzhYXysA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-musl@0.42.0':
-    resolution: {integrity: sha512-zN5OfstL0avgt/IgvRu0zjQzVh/EPkcLzs33E9LMAzpqlLWiPWeMDZyMGFlSRGOdDjuNmlZBCgj0pFnK5u32TQ==}
+  '@oxfmt/binding-linux-riscv64-musl@0.62.0':
+    resolution: {integrity: sha512-BhZDNo5GOU5nC378RhD0/XpvaEBHsH3HLgJp8YZX3A0InC7oivzA63HsRmiXFLtLSHAstEVrDf6fbC7Rs8Jh/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-s390x-gnu@0.42.0':
-    resolution: {integrity: sha512-9X6+H2L0qMc2sCAgO9HS03bkGLMKvOFjmEdchaFlany3vNZOjnVui//D8k/xZAtQv2vaCs1reD5KAgPoIU4msA==}
+  '@oxfmt/binding-linux-s390x-gnu@0.62.0':
+    resolution: {integrity: sha512-UyAFmyHkgSgUJ/wOM4p3U8AC2yAFvRH5PNBs7TnK0fObTT/XSWcdr/lAzPSWaekHaZFaMeFZyk9n93Joq3J93A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-gnu@0.42.0':
-    resolution: {integrity: sha512-BajxJ6KQvMMdpXGPWhBGyjb2Jvx4uec0w+wi6TJZ6Tv7+MzPwe0pO8g5h1U0jyFgoaF7mDl6yKPW3ykWcbUJRw==}
+  '@oxfmt/binding-linux-x64-gnu@0.62.0':
+    resolution: {integrity: sha512-1iYMP0leytWazFubD/WnINJuIrzRPuoL1aWEJdlGezEzDbTxcd29R4r8IUzP2oWeKst5V02uMJgR2NILlPlG6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-musl@0.42.0':
-    resolution: {integrity: sha512-0wV284I6vc5f0AqAhgAbHU2935B4bVpncPoe5n/WzVZY/KnHgqxC8iSFGeSyLWEgstFboIcWkOPck7tqbdHkzA==}
+  '@oxfmt/binding-linux-x64-musl@0.62.0':
+    resolution: {integrity: sha512-4rA/URtJSTVNVAQz6Q8wf7SaRvOXVy+TizriT9hs/Y1XhLR/R+92uWKRQG8yFWRAIEBbFHJ6WevQcl/G9SXEfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-openharmony-arm64@0.42.0':
-    resolution: {integrity: sha512-p4BG6HpGnhfgHk1rzZfyR6zcWkE7iLrWxyehHfXUy4Qa5j3e0roglFOdP/Nj5cJJ58MA3isQ5dlfkW2nNEpolw==}
+  '@oxfmt/binding-openharmony-arm64@0.62.0':
+    resolution: {integrity: sha512-mSZuFHU2ar1KLUjXpI2QBQcJ1VsOB3mOCgQXuXCpKs19dgh4u+OaovNfrWDfiJb+ihJ2+f7YFcaO9bS2dlTCXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxfmt/binding-win32-arm64-msvc@0.42.0':
-    resolution: {integrity: sha512-mn//WV60A+IetORDxYieYGAoQso4KnVRRjORDewMcod4irlRe0OSC7YPhhwaexYNPQz/GCFk+v9iUcZ2W22yxQ==}
+  '@oxfmt/binding-win32-arm64-msvc@0.62.0':
+    resolution: {integrity: sha512-OfwuhkcjDlqC4EgDojtiV9mzpLqeB9KqTOWPOjLEYBVdDCVSxqW3qzp/xcIxsbtI0UgGCnKvAqYKyY25kf5JZw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxfmt/binding-win32-ia32-msvc@0.42.0':
-    resolution: {integrity: sha512-3gWltUrvuz4LPJXWivoAxZ28Of2O4N7OGuM5/X3ubPXCEV8hmgECLZzjz7UYvSDUS3grfdccQwmjynm+51EFpw==}
+  '@oxfmt/binding-win32-ia32-msvc@0.62.0':
+    resolution: {integrity: sha512-P9uDDNFRzghO3X8QAzhkjKhK7JvtABsVn8UYtFX7uor12IAnwNt8nNIctvfWj1JkQU/kE+fmLRPiw7XlrIHsZw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxfmt/binding-win32-x64-msvc@0.42.0':
-    resolution: {integrity: sha512-Wg4TMAfQRL9J9AZevJ/ZNy3uyyDztDYQtGr4P8UyyzIhLhFrdSmz1J/9JT+rv0fiCDLaFOBQnj3f3K3+a5PzDQ==}
+  '@oxfmt/binding-win32-x64-msvc@0.62.0':
+    resolution: {integrity: sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -5924,10 +5924,18 @@ packages:
       typescript:
         optional: true
 
-  oxfmt@0.42.0:
-    resolution: {integrity: sha512-QhejGErLSMReNuZ6vxgFHDyGoPbjTRNi6uGHjy0cvIjOQFqD6xmr/T+3L41ixR3NIgzcNiJ6ylQKpvShTgDfqg==}
+  oxfmt@0.62.0:
+    resolution: {integrity: sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
 
   oxlint@1.77.0:
     resolution: {integrity: sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg==}
@@ -9775,61 +9783,61 @@ snapshots:
   '@opentelemetry/api@1.9.0':
     optional: true
 
-  '@oxfmt/binding-android-arm-eabi@0.42.0':
+  '@oxfmt/binding-android-arm-eabi@0.62.0':
     optional: true
 
-  '@oxfmt/binding-android-arm64@0.42.0':
+  '@oxfmt/binding-android-arm64@0.62.0':
     optional: true
 
-  '@oxfmt/binding-darwin-arm64@0.42.0':
+  '@oxfmt/binding-darwin-arm64@0.62.0':
     optional: true
 
-  '@oxfmt/binding-darwin-x64@0.42.0':
+  '@oxfmt/binding-darwin-x64@0.62.0':
     optional: true
 
-  '@oxfmt/binding-freebsd-x64@0.42.0':
+  '@oxfmt/binding-freebsd-x64@0.62.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.42.0':
+  '@oxfmt/binding-linux-arm-gnueabihf@0.62.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.42.0':
+  '@oxfmt/binding-linux-arm-musleabihf@0.62.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-gnu@0.42.0':
+  '@oxfmt/binding-linux-arm64-gnu@0.62.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-musl@0.42.0':
+  '@oxfmt/binding-linux-arm64-musl@0.62.0':
     optional: true
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.42.0':
+  '@oxfmt/binding-linux-ppc64-gnu@0.62.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.42.0':
+  '@oxfmt/binding-linux-riscv64-gnu@0.62.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-musl@0.42.0':
+  '@oxfmt/binding-linux-riscv64-musl@0.62.0':
     optional: true
 
-  '@oxfmt/binding-linux-s390x-gnu@0.42.0':
+  '@oxfmt/binding-linux-s390x-gnu@0.62.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-gnu@0.42.0':
+  '@oxfmt/binding-linux-x64-gnu@0.62.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-musl@0.42.0':
+  '@oxfmt/binding-linux-x64-musl@0.62.0':
     optional: true
 
-  '@oxfmt/binding-openharmony-arm64@0.42.0':
+  '@oxfmt/binding-openharmony-arm64@0.62.0':
     optional: true
 
-  '@oxfmt/binding-win32-arm64-msvc@0.42.0':
+  '@oxfmt/binding-win32-arm64-msvc@0.62.0':
     optional: true
 
-  '@oxfmt/binding-win32-ia32-msvc@0.42.0':
+  '@oxfmt/binding-win32-ia32-msvc@0.62.0':
     optional: true
 
-  '@oxfmt/binding-win32-x64-msvc@0.42.0':
+  '@oxfmt/binding-win32-x64-msvc@0.62.0':
     optional: true
 
   '@oxlint/binding-android-arm-eabi@1.77.0':
@@ -16148,29 +16156,29 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  oxfmt@0.42.0:
+  oxfmt@0.62.0:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.42.0
-      '@oxfmt/binding-android-arm64': 0.42.0
-      '@oxfmt/binding-darwin-arm64': 0.42.0
-      '@oxfmt/binding-darwin-x64': 0.42.0
-      '@oxfmt/binding-freebsd-x64': 0.42.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.42.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.42.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.42.0
-      '@oxfmt/binding-linux-arm64-musl': 0.42.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.42.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.42.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.42.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.42.0
-      '@oxfmt/binding-linux-x64-gnu': 0.42.0
-      '@oxfmt/binding-linux-x64-musl': 0.42.0
-      '@oxfmt/binding-openharmony-arm64': 0.42.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.42.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.42.0
-      '@oxfmt/binding-win32-x64-msvc': 0.42.0
+      '@oxfmt/binding-android-arm-eabi': 0.62.0
+      '@oxfmt/binding-android-arm64': 0.62.0
+      '@oxfmt/binding-darwin-arm64': 0.62.0
+      '@oxfmt/binding-darwin-x64': 0.62.0
+      '@oxfmt/binding-freebsd-x64': 0.62.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.62.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.62.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.62.0
+      '@oxfmt/binding-linux-arm64-musl': 0.62.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.62.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.62.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.62.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.62.0
+      '@oxfmt/binding-linux-x64-gnu': 0.62.0
+      '@oxfmt/binding-linux-x64-musl': 0.62.0
+      '@oxfmt/binding-openharmony-arm64': 0.62.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.62.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.62.0
+      '@oxfmt/binding-win32-x64-msvc': 0.62.0
 
   oxlint@1.77.0:
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,8 @@
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - '@hyperlane-xyz/*'
+  - oxfmt
+  - '@oxfmt/*'
   - oxlint
   - '@oxlint/*'
 overrides:

--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -22,7 +22,7 @@ export function AppLayout({ pathName, children }: PropsWithChildren<Props>) {
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>{`Hyperlane Explorer | ${getHeadTitle(pathName)}`}</title>
       </Head>
-      <div className="min-w-screen relative flex h-full min-h-screen w-full flex-col justify-between bg-brand-gradient">
+      <div className="bg-brand-gradient relative flex h-full min-h-screen w-full min-w-screen flex-col justify-between">
         <div
           className="pointer-events-none absolute inset-0 z-0"
           style={appShellGridOverlayStyle}

--- a/src/components/layout/AppLoadingShell.tsx
+++ b/src/components/layout/AppLoadingShell.tsx
@@ -6,7 +6,7 @@ import { appShellGridOverlayStyle, appShellMainStyle } from './appShellStyles';
 
 export function AppLoadingShell({ children }: PropsWithChildren) {
   return (
-    <div className="min-w-screen relative flex min-h-screen w-full flex-col bg-brand-gradient font-sans text-black">
+    <div className="bg-brand-gradient relative flex min-h-screen w-full min-w-screen flex-col font-sans text-black">
       <div className="pointer-events-none absolute inset-0 z-0" style={appShellGridOverlayStyle} />
       <header className="relative z-10 w-full bg-black/10 px-2 py-4 backdrop-blur-md sm:px-6 sm:py-5 lg:px-12">
         <div className="flex items-center">

--- a/src/components/layout/Card.tsx
+++ b/src/components/layout/Card.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 export function Card({ className, padding = 'p-3 sm:p-4', children }: PropsWithChildren<Props>) {
   return (
-    <div className={`overflow-auto rounded bg-card-gradient shadow-card ${padding} ${className}`}>
+    <div className={`bg-card-gradient shadow-card overflow-auto rounded ${padding} ${className}`}>
       {children}
     </div>
   );

--- a/src/components/layout/SectionCard.tsx
+++ b/src/components/layout/SectionCard.tsx
@@ -17,11 +17,11 @@ export function SectionCard({
   children,
 }: PropsWithChildren<Props>) {
   return (
-    <section className={`overflow-auto rounded bg-card-gradient shadow-card ${className || ''}`}>
+    <section className={`bg-card-gradient shadow-card overflow-auto rounded ${className || ''}`}>
       {/* Muted Gray Header */}
       <div className="bg-gray-150 px-3 py-2">
         <div className="flex items-center gap-2">
-          {leading || <div className="h-2 w-2 rounded-full bg-primary-400" />}
+          {leading || <div className="bg-primary-400 h-2 w-2 rounded-full" />}
           <span
             className={`font-medium text-gray-700 ${titleSize === 'md' ? 'text-base' : 'text-sm'}`}
           >

--- a/src/components/nav/Footer.tsx
+++ b/src/components/nav/Footer.tsx
@@ -33,7 +33,7 @@ const footerLinks3 = [
 
 export function Footer() {
   return (
-    <footer className="relative z-10 bg-gradient-to-b from-transparent to-black/40 px-8 pb-5 pt-14 text-white">
+    <footer className="relative z-10 bg-gradient-to-b from-transparent to-black/40 px-8 pt-14 pb-5 text-white">
       <div className="flex flex-col items-center justify-between gap-10 sm:flex-row">
         <div className="flex items-center justify-center">
           <Image src={LogoLockup} alt="Hyperlane Explorer" className="h-10 w-auto sm:h-12" />

--- a/src/components/nav/Header.tsx
+++ b/src/components/nav/Header.tsx
@@ -71,7 +71,7 @@ export function Header({ pathName }: { pathName: string }) {
             this will make the animation a little smoother, specially for Firefox*/}
           <div
             className={`flex items-center ${
-              animateHeader && 'rotate-[0.01deg] scale-90'
+              animateHeader && 'scale-90 rotate-[0.01deg]'
             } transition-all duration-500 ease-in-out`}
           >
             <Image src={LogoLockup} alt="Hyperlane Explorer" className="h-8 w-auto sm:h-10" />
@@ -107,13 +107,13 @@ export function Header({ pathName }: { pathName: string }) {
             type="button"
             aria-expanded={isMobileMenuOpen}
             aria-label="Toggle navigation menu"
-            className="rounded border border-white bg-primary-500 px-4 py-1 transition-all hover:opacity-80 active:opacity-70"
+            className="bg-primary-500 rounded border border-white px-4 py-1 transition-all hover:opacity-80 active:opacity-70"
             onClick={() => setIsMobileMenuOpen((open) => !open)}
           >
             <DropdownButton />
           </button>
           {isMobileMenuOpen && (
-            <div className="absolute right-0 top-full mt-3 min-w-[12rem] bg-[rgba(13,6,18,0.95)] px-8 py-7 backdrop-blur-sm">
+            <div className="absolute top-full right-0 mt-3 min-w-[12rem] bg-[rgba(13,6,18,0.95)] px-8 py-7 backdrop-blur-sm">
               <MobileNavLink href="/" closeDropdown={() => setIsMobileMenuOpen(false)}>
                 HOME
               </MobileNavLink>
@@ -162,12 +162,12 @@ function MobileNavLink({
   return (
     <Link
       href={href}
-      className="flex cursor-pointer items-center py-4 pl-3 decoration-primary-500 decoration-4 underline-offset-[2px] transition-all hover:underline active:opacity-80"
+      className="decoration-primary-500 flex cursor-pointer items-center py-4 pl-3 decoration-4 underline-offset-[2px] transition-all hover:underline active:opacity-80"
       onClick={closeDropdown}
       rel={isExternal ? 'noopener noreferrer' : undefined}
       target={isExternal ? '_blank' : undefined}
     >
-      <span className="text-xl font-medium uppercase text-white">{children}</span>
+      <span className="text-xl font-medium text-white uppercase">{children}</span>
     </Link>
   );
 }

--- a/src/components/nav/InfoBanner.tsx
+++ b/src/components/nav/InfoBanner.tsx
@@ -4,7 +4,7 @@ export function InfoBanner() {
       href="https://explorer-v2.hyperlane.xyz"
       target="_blank"
       rel="noopener noreferrer"
-      className="block w-full bg-primary-600 py-1.5 text-center text-sm text-white transition-all duration-300 hover:bg-primary-700 active:bg-primary-800"
+      className="bg-primary-600 hover:bg-primary-700 active:bg-primary-800 block w-full py-1.5 text-center text-sm text-white transition-all duration-300"
     >
       This is the explorer for Hyperlane version 3.{' '}
       <span className="underline underline-offset-2">Use version 2</span>

--- a/src/components/search/MiniSearchBar.tsx
+++ b/src/components/search/MiniSearchBar.tsx
@@ -30,7 +30,7 @@ export function MiniSearchBar() {
             placeholder="Hash or address"
             className="h-8 w-36 rounded bg-white px-2.5 py-2 text-sm font-light transition-[width] duration-500 ease-in-out placeholder:text-gray-600 focus:w-64 focus:outline-none"
           />
-          <div className="flex h-8 w-8 items-center justify-center rounded bg-accent-600 duration-500 hover:bg-accent-700">
+          <div className="bg-accent-600 hover:bg-accent-700 flex h-8 w-8 items-center justify-center rounded duration-500">
             <IconButton type="submit" title="Search">
               <SearchIcon width={16} height={16} color={Color.white} />
             </IconButton>

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -40,7 +40,7 @@ export function SearchBar({ value, placeholder, onChangeValue, isFetching }: Pro
       )}
       {!isFetching && value && (
         <div
-          className={`${iconStyle} bg-accent-600 duration-500 hover:bg-accent-700 sm:h-12 sm:w-12`}
+          className={`${iconStyle} bg-accent-600 hover:bg-accent-700 duration-500 sm:h-12 sm:w-12`}
         >
           <IconButton
             title="Clear search"

--- a/src/components/search/SearchFilterBar.tsx
+++ b/src/components/search/SearchFilterBar.tsx
@@ -90,7 +90,7 @@ function ChainSelector({
       <button
         type="button"
         className={clsx(
-          'flex items-center justify-center rounded border border-accent-600 px-1.5 py-1 text-sm font-medium transition-all hover:opacity-80 active:opacity-70 sm:min-w-[5.8rem] sm:px-2.5',
+          'border-accent-600 flex items-center justify-center rounded border px-1.5 py-1 text-sm font-medium transition-all hover:opacity-80 active:opacity-70 sm:min-w-[5.8rem] sm:px-2.5',
           value ? 'bg-accent-600 pr-7 text-white sm:pr-8' : 'text-accent-600',
         )}
         onClick={open}
@@ -164,7 +164,7 @@ function DatetimeSelector({
           </>
         }
         buttonClassname={clsx(
-          'flex items-center justify-center rounded border border-accent-600 px-2 py-1 text-sm font-medium transition-all hover:opacity-80 active:opacity-70 sm:px-3',
+          'border-accent-600 flex items-center justify-center rounded border px-2 py-1 text-sm font-medium transition-all hover:opacity-80 active:opacity-70 sm:px-3',
           hasValue ? 'bg-accent-600 pr-7 text-white sm:pr-8' : 'text-accent-600',
         )}
         panelClassname="w-60"
@@ -172,7 +172,7 @@ function DatetimeSelector({
         {({ close }) => (
           <div className="p-4" key="date-time-selector">
             <div className="flex items-center justify-between">
-              <h3 className="font-medium text-primary-800">Time Range</h3>
+              <h3 className="text-primary-800 font-medium">Time Range</h3>
               <div className="flex pt-1">
                 <TextButton classes="text-sm font-medium text-accent-600" onClick={onClickClear}>
                   Clear
@@ -180,9 +180,9 @@ function DatetimeSelector({
               </div>
             </div>
             <div className="flex flex-col">
-              <h4 className="mb-1 mt-3 text-sm font-medium text-gray-500">Start Time</h4>
+              <h4 className="mt-3 mb-1 text-sm font-medium text-gray-500">Start Time</h4>
               <DatetimeField timestamp={startTime} onChange={setStartTime} />
-              <h4 className="mb-1 mt-3 text-sm font-medium text-gray-500">End Time</h4>
+              <h4 className="mt-3 mb-1 text-sm font-medium text-gray-500">End Time</h4>
               <DatetimeField timestamp={endTime} onChange={setEndTime} />
             </div>
             <SolidButton
@@ -204,7 +204,7 @@ function ClearButton({ onClick }: { onClick: () => void }) {
     <button
       type="button"
       onClick={onClick}
-      className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded-full bg-primary-300/80 p-1 hover:opacity-80"
+      className="bg-primary-300/80 absolute top-1/2 right-1.5 -translate-y-1/2 rounded-full p-1 hover:opacity-80"
     >
       <XIcon color="white" height={10} width={10} />
     </button>
@@ -245,7 +245,7 @@ function StatusSelector({
           </>
         }
         buttonClassname={clsx(
-          'flex items-center justify-center rounded border border-accent-600 px-2 py-1 text-sm font-medium transition-all hover:opacity-80 active:opacity-70 sm:px-3',
+          'border-accent-600 flex items-center justify-center rounded border px-2 py-1 text-sm font-medium transition-all hover:opacity-80 active:opacity-70 sm:px-3',
           hasValue ? 'bg-accent-600 pr-7 text-white sm:pr-8' : 'text-accent-600',
         )}
         panelClassname="w-36"
@@ -258,7 +258,7 @@ function StatusSelector({
                 type="button"
                 className={clsx(
                   'w-full rounded px-3 py-2 text-left text-sm transition-colors hover:bg-gray-100',
-                  value === option.value && 'bg-accent-50 font-medium text-accent-600',
+                  value === option.value && 'bg-accent-50 text-accent-600 font-medium',
                 )}
                 onClick={() => {
                   onChangeValue(option.value);

--- a/src/components/search/SearchStates.tsx
+++ b/src/components/search/SearchStates.tsx
@@ -9,14 +9,14 @@ import ShrugIcon from '../../images/icons/shrug.svg';
 export function SearchFetching({ show, isPiFetching }: { show: boolean; isPiFetching?: boolean }) {
   return (
     // Absolute position for overlaying cross-fade
-    <div className="absolute left-0 right-0 top-10">
+    <div className="absolute top-10 right-0 left-0">
       <Fade show={show}>
         <div className="my-10 flex justify-center">
           <div className="flex max-w-md flex-col items-center justify-center px-3 py-5">
             <div className="flex items-center justify-center">
               <SpinnerIcon width={40} height={40} />
             </div>
-            <div className="mt-4 text-center font-light leading-loose text-gray-700">
+            <div className="mt-4 text-center leading-loose font-light text-gray-700">
               {isPiFetching ? 'Searching override chains for messages' : 'Searching for messages'}
             </div>
           </div>
@@ -39,12 +39,12 @@ export function SearchError({
 }) {
   return (
     // Absolute position for overlaying cross-fade
-    <div className="absolute left-0 right-0 top-10">
+    <div className="absolute top-10 right-0 left-0">
       <Fade show={show}>
         <div className="my-10 flex justify-center">
           <div className="flex max-w-md flex-col items-center justify-center px-3 py-5">
             <Image src={imgSrc} width={imgWidth} className="opacity-80" alt="" />
-            <div className="mt-4 text-center font-light leading-loose text-gray-700">{text}</div>
+            <div className="mt-4 text-center leading-loose font-light text-gray-700">{text}</div>
           </div>
         </div>
       </Fade>

--- a/src/features/chains/loadChainMetadata.ts
+++ b/src/features/chains/loadChainMetadata.ts
@@ -24,13 +24,10 @@ export async function loadChainMetadata(
 
   const registryChainMetadata = await registry.getMetadata();
   const metadataWithLogos = await promiseObjAll(
-    objMap(
-      registryChainMetadata,
-      async (chainName, metadata): Promise<ChainMetadata> => ({
-        ...metadata,
-        logoURI: `${links.imgPath}/chains/${chainName}/logo.svg`,
-      }),
-    ),
+    objMap(registryChainMetadata, async (chainName, metadata): Promise<ChainMetadata> => ({
+      ...metadata,
+      logoURI: `${links.imgPath}/chains/${chainName}/logo.svg`,
+    })),
   );
 
   const mergedMetadata = mergeChainMetadataMap(metadataWithLogos, overrideChainMetadata);

--- a/src/features/messages/MessageDetailsInner.tsx
+++ b/src/features/messages/MessageDetailsInner.tsx
@@ -150,16 +150,16 @@ export function MessageDetailsInner({ messageId, message: messageFromUrlParams }
 
   return (
     <>
-      <div className="flex items-center justify-between rounded bg-accent-gradient px-3 py-3 shadow-accent-glow">
+      <div className="bg-accent-gradient shadow-accent-glow flex items-center justify-between rounded px-3 py-3">
         <div className="flex min-w-0 items-center gap-2">
-          <div className="h-2.5 w-2.5 rounded-full bg-cream-300" />
+          <div className="bg-cream-300 h-2.5 w-2.5 rounded-full" />
           <h2 className="text-lg font-medium text-white">{`${
             isIcaMsg ? 'ICA ' : ''
           }Message to ${getChainDisplayName(chainMetadataResolver, destinationChainName)}`}</h2>
           {showTxLink && (
             <Link
               href={`/tx/${origin.hash}`}
-              className="text-sm font-medium text-cream-300 transition-colors hover:text-white"
+              className="text-cream-300 text-sm font-medium transition-colors hover:text-white"
             >
               View all {txMessageCount} messages in tx
             </Link>
@@ -306,7 +306,7 @@ function StatusHeader({
   return (
     <div className="flex items-center">
       <h3 className="mr-2 text-lg font-medium text-white">{text}</h3>
-      {duration && <span className="mr-3 text-sm text-cream-300">({duration})</span>}
+      {duration && <span className="text-cream-300 mr-3 text-sm">({duration})</span>}
       {icon}
     </div>
   );

--- a/src/features/messages/MessageDetailsLoading.tsx
+++ b/src/features/messages/MessageDetailsLoading.tsx
@@ -4,9 +4,9 @@ import { SectionCard } from '../../components/layout/SectionCard';
 export function MessageDetailsLoading() {
   return (
     <div>
-      <div className="flex items-center justify-between rounded bg-accent-gradient px-3 py-3 shadow-accent-glow">
+      <div className="bg-accent-gradient shadow-accent-glow flex items-center justify-between rounded px-3 py-3">
         <div className="flex items-center gap-2">
-          <div className="h-2.5 w-2.5 rounded-full bg-cream-300/70" />
+          <div className="bg-cream-300/70 h-2.5 w-2.5 rounded-full" />
           <div className="h-6 w-52 animate-pulse rounded bg-white/20" />
         </div>
         <div className="h-6 w-36 animate-pulse rounded bg-white/20" />

--- a/src/features/messages/MessageSearch.tsx
+++ b/src/features/messages/MessageSearch.tsx
@@ -352,8 +352,8 @@ export function MessageSearch() {
         />
       )}
       <Card className="relative mt-4 min-h-[38rem] w-full" padding="">
-        <div className="flex items-center justify-between px-2 pb-3 pt-3.5 sm:px-4 md:px-5">
-          <h2 className="w-min pl-0.5 font-medium text-primary-800 sm:w-fit">
+        <div className="flex items-center justify-between px-2 pt-3.5 pb-3 sm:px-4 md:px-5">
+          <h2 className="text-primary-800 w-min pl-0.5 font-medium sm:w-fit">
             {!hasInput ? 'Latest Messages' : 'Search Results'}
           </h2>
           <div className="flex items-center space-x-2 md:space-x-4">
@@ -390,7 +390,7 @@ export function MessageSearch() {
           allowAddress={true}
         />
         {looksLikeWarpRoute && !isWarpRouteMapLoaded && (
-          <div className="absolute left-0 right-0 top-10">
+          <div className="absolute top-10 right-0 left-0">
             <div className="my-10 flex justify-center">
               <div className="flex max-w-md flex-col items-center justify-center px-3 py-5 text-center">
                 <div className="text-gray-700">Loading warp route data...</div>
@@ -399,7 +399,7 @@ export function MessageSearch() {
           </div>
         )}
         {isUnknownWarpRoute && (
-          <div className="absolute left-0 right-0 top-10">
+          <div className="absolute top-10 right-0 left-0">
             <div className="my-10 flex justify-center">
               <div className="flex max-w-md flex-col items-center justify-center px-3 py-5 text-center">
                 <div className="text-gray-700">
@@ -421,7 +421,7 @@ function RefreshButton({ loading, onClick }: { loading: boolean; onClick: () => 
   return (
     <IconButton
       onClick={onClick}
-      className="flex h-[30px] w-[30px] items-center justify-center rounded bg-accent-600 duration-500 hover:bg-accent-700"
+      className="bg-accent-600 hover:bg-accent-700 flex h-[30px] w-[30px] items-center justify-center rounded duration-500"
       disabled={loading}
     >
       <RefreshIcon color="white" height={18} width={18} />

--- a/src/features/messages/MessageSearchLoading.tsx
+++ b/src/features/messages/MessageSearchLoading.tsx
@@ -6,22 +6,22 @@ export function MessageSearchLoading() {
     <div className="animate-pulse">
       <div className="flex w-full items-center rounded bg-white p-1">
         <div className="h-10 flex-1 rounded bg-gray-100 sm:h-12" />
-        <div className="ml-1 h-10 w-10 rounded bg-accent-600/80 sm:h-12 sm:w-12" />
+        <div className="bg-accent-600/80 ml-1 h-10 w-10 rounded sm:h-12 sm:w-12" />
       </div>
 
       <Card className="relative mt-4 min-h-[38rem] w-full" padding="">
-        <div className="flex items-center justify-between px-2 pb-3 pt-3.5 sm:px-4 md:px-5">
+        <div className="flex items-center justify-between px-2 pt-3.5 pb-3 sm:px-4 md:px-5">
           <div className="h-6 w-32 rounded bg-gray-200" />
           <SearchFilterBarSkeleton />
         </div>
 
         <div className="px-3 pb-3 sm:px-4 md:px-5">
-          <div className="hidden grid-cols-[1.2fr_1.2fr_1.6fr_1.6fr_1.4fr_1fr_1.4fr_24px] gap-4 border-b border-gray-100 pb-3 text-xs font-medium uppercase tracking-wide text-gray-500 sm:grid" />
+          <div className="hidden grid-cols-[1.2fr_1.2fr_1.6fr_1.6fr_1.4fr_1fr_1.4fr_24px] gap-4 border-b border-gray-100 pb-3 text-xs font-medium tracking-wide text-gray-500 uppercase sm:grid" />
           <div className="space-y-2 py-3">
             {Array.from({ length: 8 }).map((_, i) => (
               <div
                 key={i}
-                className="grid grid-cols-[1.2fr_1.2fr_1.6fr_1.6fr_1.4fr_1fr_1.4fr_24px] items-center gap-4 border-b border-primary-50 py-2 last:border-0"
+                className="border-primary-50 grid grid-cols-[1.2fr_1.2fr_1.6fr_1.6fr_1.4fr_1fr_1.4fr_24px] items-center gap-4 border-b py-2 last:border-0"
               >
                 <div className="h-5 w-20 rounded bg-gray-200" />
                 <div className="h-5 w-20 rounded bg-gray-200" />

--- a/src/features/messages/MessageTable.tsx
+++ b/src/features/messages/MessageTable.tsx
@@ -73,8 +73,8 @@ export function MessageTable({
     <table className="mb-1 w-full">
       <thead>
         <tr className="border-b border-gray-100">
-          <th className={`${styles.header} pl-3 xs:text-left sm:pl-6`}>Origin</th>
-          <th className={`${styles.header} pl-1 xs:text-left sm:pl-2`}>Destination</th>
+          <th className={`${styles.header} xs:text-left pl-3 sm:pl-6`}>Origin</th>
+          <th className={`${styles.header} xs:text-left pl-1 sm:pl-2`}>Destination</th>
           <th className={`${styles.header} hidden sm:table-cell`}>Sender</th>
           <th className={`${styles.header} hidden sm:table-cell`}>Recipient</th>
           <th className={`${styles.header} hidden lg:table-cell`}>Origin Tx</th>
@@ -86,7 +86,7 @@ export function MessageTable({
         {messageList.map((m) => (
           <tr
             key={`message-${m.id}`}
-            className={`relative cursor-pointer border-b border-primary-50 last:border-0 hover:bg-accent-50 active:bg-accent-100 ${
+            className={`border-primary-50 hover:bg-accent-50 active:bg-accent-100 relative cursor-pointer border-b last:border-0 ${
               isFetching && 'blur-xs'
             } transition-all duration-500`}
           >

--- a/src/features/messages/SearchFilterBarSkeleton.tsx
+++ b/src/features/messages/SearchFilterBarSkeleton.tsx
@@ -1,10 +1,10 @@
 export function SearchFilterBarSkeleton() {
   return (
     <div className="flex items-center gap-2 md:gap-4">
-      <div className="h-8 w-20 rounded border border-accent-600/40 bg-accent-50/40" />
-      <div className="h-8 w-24 rounded border border-accent-600/40 bg-accent-50/40" />
-      <div className="h-8 w-16 rounded border border-accent-600/40 bg-accent-50/40" />
-      <div className="h-8 w-20 rounded border border-accent-600/40 bg-accent-50/40" />
+      <div className="border-accent-600/40 bg-accent-50/40 h-8 w-20 rounded border" />
+      <div className="border-accent-600/40 bg-accent-50/40 h-8 w-24 rounded border" />
+      <div className="border-accent-600/40 bg-accent-50/40 h-8 w-16 rounded border" />
+      <div className="border-accent-600/40 bg-accent-50/40 h-8 w-20 rounded border" />
     </div>
   );
 }

--- a/src/features/messages/cards/CodeBlock.tsx
+++ b/src/features/messages/cards/CodeBlock.tsx
@@ -36,13 +36,13 @@ export function CollapsibleLabelAndCodeBlock({
 
 export function CodeBlock({ value }: { value: string }) {
   return (
-    <div className="relative mt-1.5 min-h-[1.5rem] max-w-full break-words rounded-md bg-[#e5e7eb] px-3 py-2 pr-8 font-mono text-sm font-light">
+    <div className="relative mt-1.5 min-h-[1.5rem] max-w-full rounded-md bg-[#e5e7eb] px-3 py-2 pr-8 font-mono text-sm font-light break-words">
       {value}
       <CopyButton
         copyValue={value}
         width={12}
         height={12}
-        className="absolute right-2 top-1.5 opacity-50"
+        className="absolute top-1.5 right-2 opacity-50"
       />
     </div>
   );

--- a/src/features/messages/cards/CollateralCards.tsx
+++ b/src/features/messages/cards/CollateralCards.tsx
@@ -104,7 +104,7 @@ function RebalanceList({ rebalances }: { rebalances: RebalanceInfo[] }) {
             {rebalance.messageId && (
               <Link
                 href={`/message/${rebalance.messageId}`}
-                className="text-primary-600 underline hover:text-primary-800"
+                className="text-primary-600 hover:text-primary-800 underline"
                 target="_blank"
               >
                 View message →

--- a/src/features/messages/cards/GasDetailsCard.tsx
+++ b/src/features/messages/cards/GasDetailsCard.tsx
@@ -115,7 +115,7 @@ export function GasDetailsCard({ message, blur, igpPayments = {} }: Props) {
             href={docLinks.gas}
             target="_blank"
             rel="noopener noreferrer"
-            className="cursor-pointer text-primary-800 transition-all hover:text-primary-700 active:text-primary-600"
+            className="text-primary-800 hover:text-primary-700 active:text-primary-600 cursor-pointer transition-all"
           >
             Learn more about gas on Hyperlane.
           </a>

--- a/src/features/messages/cards/IcaDetailsCard.tsx
+++ b/src/features/messages/cards/IcaDetailsCard.tsx
@@ -116,7 +116,7 @@ function IcaStatusPanel({
             {titleAccessory}
           </div>
           <div className="mt-2 flex items-start gap-2">
-            <div className={clsx('min-w-0 flex-1 break-all font-mono text-xs', styles.body)}>
+            <div className={clsx('min-w-0 flex-1 font-mono text-xs break-all', styles.body)}>
               {commitment}
             </div>
             <CopyButton
@@ -491,7 +491,7 @@ export function IcaDetailsCard({ message, blur, debugResult }: Props) {
                     ) : ccipReadData?.urls && ccipReadData.urls.length > 0 ? (
                       <div className="mt-2 space-y-1">
                         {ccipReadData.urls.map((url, i) => (
-                          <div key={i} className="break-all font-mono text-xs text-gray-600">
+                          <div key={i} className="font-mono text-xs break-all text-gray-600">
                             {url}
                           </div>
                         ))}
@@ -598,7 +598,7 @@ export function IcaDetailsCard({ message, blur, debugResult }: Props) {
 
                 {/* Loading state for reveal calls */}
                 {decodeResult.messageType === IcaMessageType.REVEAL && isRevealFetching && (
-                  <div className="py-2 text-sm italic text-gray-500">
+                  <div className="py-2 text-sm text-gray-500 italic">
                     Fetching calls from destination transaction...
                   </div>
                 )}
@@ -607,7 +607,7 @@ export function IcaDetailsCard({ message, blur, debugResult }: Props) {
                 {decodeResult.messageType === IcaMessageType.REVEAL &&
                   isRevealError &&
                   !revealCalls && (
-                    <div className="py-2 text-sm italic text-gray-500">
+                    <div className="py-2 text-sm text-gray-500 italic">
                       Could not fetch calls from destination transaction.
                     </div>
                   )}
@@ -616,7 +616,7 @@ export function IcaDetailsCard({ message, blur, debugResult }: Props) {
                 {decodeResult.messageType === IcaMessageType.REVEAL &&
                   !destination?.hash &&
                   !isRevealFetching && (
-                    <div className="py-2 text-sm italic text-gray-500">
+                    <div className="py-2 text-sm text-gray-500 italic">
                       Calls will be shown once the message is processed on the destination chain.
                     </div>
                   )}
@@ -639,7 +639,7 @@ export function IcaDetailsCard({ message, blur, debugResult }: Props) {
                 {/* Empty calls for CALLS type */}
                 {decodeResult.messageType === IcaMessageType.CALLS &&
                   decodeResult.calls.length === 0 && (
-                    <div className="py-2 text-sm italic text-gray-500">
+                    <div className="py-2 text-sm text-gray-500 italic">
                       No calls in this message.
                     </div>
                   )}
@@ -647,7 +647,7 @@ export function IcaDetailsCard({ message, blur, debugResult }: Props) {
             )}
           </>
         ) : (
-          <div className="py-4 italic text-red-500">
+          <div className="py-4 text-red-500 italic">
             Unable to decode Interchain Account message body. The message format may be
             unrecognized.
           </div>

--- a/src/features/messages/cards/IsmDetailsCard.tsx
+++ b/src/features/messages/cards/IsmDetailsCard.tsx
@@ -30,7 +30,7 @@ export function IsmDetailsCard({ ismDetails, blur }: Props) {
             href={docLinks.ism}
             target="_blank"
             rel="noopener noreferrer"
-            className="cursor-pointer text-primary-600 transition-all hover:text-primary-500 active:text-primary-400"
+            className="text-primary-600 hover:text-primary-500 active:text-primary-400 cursor-pointer transition-all"
           >
             Learn more about ISMs.
           </a>

--- a/src/features/messages/cards/TransactionCard.tsx
+++ b/src/features/messages/cards/TransactionCard.tsx
@@ -100,7 +100,7 @@ export function DestinationTransactionCard({
               debugResult ? ': ' + debugStatusToDesc[debugResult.status] : ''
             }`}</div>
             {!!debugResult?.description && (
-              <div className="mt-5 break-words text-center text-sm leading-relaxed text-gray-800">
+              <div className="mt-5 text-center text-sm leading-relaxed break-words text-gray-800">
                 {debugResult.description}
               </div>
             )}
@@ -118,7 +118,7 @@ export function DestinationTransactionCard({
             <div className="mt-2 max-w-xs text-sm">
               Permissionless Interoperability (PI) chains require a config.
             </div>
-            <div className="mb-6 mt-2 max-w-xs text-sm">
+            <div className="mt-2 mb-6 max-w-xs text-sm">
               Please{' '}
               <button className="underline underline-offset-2" onClick={open}>
                 add metadata

--- a/src/features/messages/cards/WarpRouteIsmDetailsCard.tsx
+++ b/src/features/messages/cards/WarpRouteIsmDetailsCard.tsx
@@ -48,7 +48,7 @@ export function WarpRouteIsmDetailsCard({ message, warpRouteDetails, blur }: Pro
         className="flex w-full items-center gap-2"
       >
         <LockIcon width={22} height={26} color="#3d304c" className="opacity-70" />
-        <h3 className="text-md font-medium text-primary-800">Warp Route Security</h3>
+        <h3 className="text-md text-primary-800 font-medium">Warp Route Security</h3>
         {/* Stop propagation so clicking / Enter on the help icon doesn't
             toggle the card. The tooltip itself is hover-driven so this is
             mostly cosmetic, but it preserves the click-to-not-toggle

--- a/src/features/messages/cards/WarpRouteVisualizationCard.tsx
+++ b/src/features/messages/cards/WarpRouteVisualizationCard.tsx
@@ -66,7 +66,7 @@ export function WarpRouteVisualizationCard({ message, warpRouteDetails, blur }: 
       <div className="flex w-full items-center justify-between">
         <button onClick={() => setIsExpanded(!isExpanded)} className="flex items-center gap-2">
           <Image src={HubIcon} width={28} height={28} alt="" className="opacity-80" />
-          <h3 className="text-md font-medium text-primary-800">Warp Route Overview</h3>
+          <h3 className="text-md text-primary-800 font-medium">Warp Route Overview</h3>
           <Tooltip
             id="warp-route-overview-info"
             content="Visualization of the warp route showing all connected chains, their configuration, and collateral balances"

--- a/src/features/messages/cards/WarpTransferDetailsCard.tsx
+++ b/src/features/messages/cards/WarpTransferDetailsCard.tsx
@@ -87,7 +87,7 @@ export function WarpTransferDetailsCard({ message, warpRouteDetails, blur }: Pro
         {/* Details Column */}
         <div className="min-w-0 flex-1 space-y-4">
           {isCollateral && (
-            <div className="rounded bg-primary-50 px-3 py-2 text-xs text-primary-700">
+            <div className="bg-primary-50 text-primary-700 rounded px-3 py-2 text-xs">
               <span className="font-medium">Collateral-backed route:</span> This transfer uses
               locked collateral on the destination chain
             </div>
@@ -183,10 +183,10 @@ function TokenLogos({
   return (
     <div className="flex flex-shrink-0 items-center justify-center">
       <div className="relative" style={{ width: 73, height: 73 }}>
-        <div className="absolute left-0 top-0">
+        <div className="absolute top-0 left-0">
           <TokenIcon token={originToken} size={48} />
         </div>
-        <div className="absolute bottom-0 right-0 rounded-full ring-2 ring-white">
+        <div className="absolute right-0 bottom-0 rounded-full ring-2 ring-white">
           <TokenIcon token={destinationToken} size={48} />
         </div>
       </div>

--- a/src/features/messages/cards/ismRender/IsmConfigDisplay.tsx
+++ b/src/features/messages/cards/ismRender/IsmConfigDisplay.tsx
@@ -63,14 +63,14 @@ function IsmRow({
       {node.address ? (
         <AddressInline address={node.address} chainName={chainName} />
       ) : (
-        <span className="text-xs italic text-gray-400">no address</span>
+        <span className="text-xs text-gray-400 italic">no address</span>
       )}
       {annotation && (
         <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-600">
           {annotation}
         </span>
       )}
-      {node.error && <span className="text-xs italic text-amber-700">({node.error})</span>}
+      {node.error && <span className="text-xs text-amber-700 italic">({node.error})</span>}
     </div>
   );
 }

--- a/src/features/messages/cards/ismRender/OwnerDisplay.tsx
+++ b/src/features/messages/cards/ismRender/OwnerDisplay.tsx
@@ -34,7 +34,7 @@ function OwnerKindBadge({ kind, safeInfo }: { kind: OwnerKind; safeInfo?: SafeIn
     ? `Safe ${safeInfo.threshold}/${safeInfo.ownerCount}`
     : `Safe (threshold ${safeInfo?.threshold ?? '?'})`;
   return (
-    <span className="rounded bg-primary-50 px-1.5 py-0.5 text-xs font-medium text-primary-700">
+    <span className="bg-primary-50 text-primary-700 rounded px-1.5 py-0.5 text-xs font-medium">
       {label}
     </span>
   );

--- a/src/features/messages/warpVisualization/RouteEnrollments.tsx
+++ b/src/features/messages/warpVisualization/RouteEnrollments.tsx
@@ -22,7 +22,7 @@ export function RouteEnrollments({ visualization }: Props) {
 
   return (
     <div className="space-y-2">
-      <div className="text-xs font-medium uppercase tracking-wide text-gray-500">
+      <div className="text-xs font-medium tracking-wide text-gray-500 uppercase">
         Route enrollments
       </div>
       <div className="space-y-2">

--- a/src/features/messages/warpVisualization/WarpRouteGraph.tsx
+++ b/src/features/messages/warpVisualization/WarpRouteGraph.tsx
@@ -345,16 +345,16 @@ export function WarpRouteGraph({
           {/* Arrow with transfer amount */}
           <div className="flex flex-col items-center">
             <div className="flex items-center">
-              <div className="h-0.5 w-8 bg-primary-500" />
+              <div className="bg-primary-500 h-0.5 w-8" />
               {transferAmountDisplay && tokenSymbol && (
-                <div className="rounded border border-primary-500 bg-white px-2 py-1">
-                  <span className="block max-w-[112px] truncate text-xs font-medium text-primary-700">
+                <div className="border-primary-500 rounded border bg-white px-2 py-1">
+                  <span className="text-primary-700 block max-w-[112px] truncate text-xs font-medium">
                     {transferAmountDisplay} {tokenSymbol}
                   </span>
                 </div>
               )}
-              <div className="h-0.5 w-8 bg-primary-500" />
-              <div className="h-0 w-0 border-b-[6px] border-l-[8px] border-t-[6px] border-b-transparent border-l-primary-500 border-t-transparent" />
+              <div className="bg-primary-500 h-0.5 w-8" />
+              <div className="border-l-primary-500 h-0 w-0 border-t-[6px] border-b-[6px] border-l-[8px] border-t-transparent border-b-transparent" />
             </div>
           </div>
 

--- a/src/features/transactions/MessageSummaryRow.tsx
+++ b/src/features/transactions/MessageSummaryRow.tsx
@@ -110,7 +110,7 @@ export function MessageSummaryRow({ message, index, forceExpanded }: Props) {
         </button>
         <Link
           href={`/message/${message.msgId}`}
-          className="shrink-0 text-xs text-primary-600 transition-colors hover:text-primary-500"
+          className="text-primary-600 hover:text-primary-500 shrink-0 text-xs transition-colors"
         >
           Open
         </Link>

--- a/src/features/transactions/TransactionDetails.tsx
+++ b/src/features/transactions/TransactionDetails.tsx
@@ -46,7 +46,7 @@ export function TransactionDetails({ txHash }: Props) {
         <button
           type="button"
           onClick={refetch}
-          className="text-sm font-medium text-primary-600 transition-colors hover:text-primary-500"
+          className="text-primary-600 hover:text-primary-500 text-sm font-medium transition-colors"
         >
           Retry
         </button>


### PR DESCRIPTION
## Summary

- upgrade oxfmt from 0.42.0 to 0.62.0
- remove the temporary Tailwind v3 ordering pin
- apply the resulting Tailwind class-order normalization

## Scope

Stacked on #339. This PR contains formatter configuration, lockfile, and formatting-only source changes; no application logic changes.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test` — 14 suites, 128 tests
- `pnpm run build`
- `oxfmt --check ./src`
- `git diff --check`
- exact-head build, format, lint, and typecheck passed in [manually dispatched CI](https://github.com/hyperlane-xyz/hyperlane-explorer/actions/runs/30943476944)
- Vercel preview deployed successfully