### PR TITLE
test: add Explorer production smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -44,6 +43,12 @@ jobs:
 
       - name: build
         run: pnpm run build
+
+      - name: Install Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Smoke test
+        run: pnpm run test:smoke
 
   typecheck:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ cache/
 /coverage
 coverage.json
 /test/outputs
+/playwright-report
+/test-results
 
 # next.js
 /.next/

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,7 @@ const createJestConfig = nextJest({
 const customJestConfig = {
   // Add more setup options before each test is run
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  testPathIgnorePatterns: ['<rootDir>/tests/smoke/'],
   moduleNameMapper: {
     // Mock aleo-sdk to avoid ESM/WASM issues in tests
     '@hyperlane-xyz/aleo-sdk': '<rootDir>/src/utils/aleo-sdk-noop.js',

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.1097.0",
+    "@playwright/test": "^1.62.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.17",
@@ -78,6 +79,7 @@
     "lint": "oxlint ./src",
     "start": "next start",
     "test": "jest",
+    "test:smoke": "playwright test",
     "format": "oxfmt ./src"
   },
   "types": "dist/src/index.d.ts"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/smoke',
+  timeout: 60_000,
+  use: {
+    baseURL: 'http://127.0.0.1:3000',
+    trace: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'pnpm start',
+    url: 'http://127.0.0.1:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 17.0.2
       next:
         specifier: 16.2.12
-        version: 16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -123,6 +123,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1097.0
         version: 3.1097.0
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -1768,6 +1771,11 @@ packages:
   '@pkgr/core@0.3.6':
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -4832,6 +4840,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -6016,6 +6029,16 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
@@ -10043,6 +10066,10 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.3.6': {}
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -14683,6 +14710,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -15935,7 +15965,7 @@ snapshots:
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu': 4.62.3
 
-  next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.2.12
       '@swc/helpers': 0.5.15
@@ -15955,6 +15985,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.2.12
       '@next/swc-win32-x64-msvc': 16.2.12
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.62.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -16345,6 +16376,14 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pngjs@5.0.0: {}
 

--- a/tests/smoke/homepage.spec.ts
+++ b/tests/smoke/homepage.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from '@playwright/test';
+
+const DELIVERED_MESSAGE_ID = '0xcddfe5f46ea816472b3ad331cee25b4d34be7280d5ba03d2358f1b5a8d049f55';
+
+test('smokes the Explorer runtime, data path, and widget layouts', async ({ page }) => {
+  const pageErrors: string[] = [];
+  const graphqlMethods: string[] = [];
+
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+  page.on('request', (request) => {
+    if (request.url().startsWith('https://explorer4.hasura.app/v1/graphql')) {
+      graphqlMethods.push(request.method());
+    }
+  });
+
+  await page.goto('/');
+
+  const searchInput = page.getByPlaceholder('Search by address, hash, message id, or warp route');
+  await expect(searchInput).toBeVisible();
+  await expect(page.locator('tbody tr').first()).toBeVisible({ timeout: 30_000 });
+
+  await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  await expect(page.getByText('Sorry, an error has occurred. Please try again later.')).toHaveCount(
+    0,
+  );
+  expect(pageErrors).toEqual([]);
+  expect(graphqlMethods).toContain('POST');
+  expect(graphqlMethods).not.toContain('GET');
+
+  await expect(page.locator('header img')).toHaveCSS('height', '40px');
+  await expect(page.locator('footer img')).toHaveCSS('height', '48px');
+  await expect(searchInput).toHaveCSS('height', '48px');
+
+  for (const label of ['Origin', 'Destination', 'Time', 'Status']) {
+    const box = await page.getByRole('button', { name: label, exact: true }).boundingBox();
+    expect(box?.height).toBeLessThan(40);
+  }
+
+  await page.getByRole('button', { name: 'Origin', exact: true }).click();
+  await expect(page.getByPlaceholder('Chain Name or ID')).toBeVisible();
+  await expect(page.getByText('Abstract', { exact: true }).first()).toBeVisible();
+
+  const pickerGrids = page.locator('[class*="htw-grid-cols-"]');
+  await expect(pickerGrids.first()).toHaveCSS('display', 'grid');
+  await expect(pickerGrids.nth(1)).toHaveCSS('display', 'grid');
+
+  const pickerControls = await pickerGrids.first().boundingBox();
+  const firstChainRow = await pickerGrids.nth(1).boundingBox();
+  expect(pickerControls?.width).toBeGreaterThan(400);
+  expect(firstChainRow?.width).toBeGreaterThan(400);
+  expect(firstChainRow?.height).toBeLessThan(70);
+
+  await page.goto(`/message/${DELIVERED_MESSAGE_ID}`);
+
+  const timeline = page.locator('.htw-pt-14').first();
+  await expect(timeline).toBeVisible({ timeout: 30_000 });
+  await expect(timeline).toHaveCSS('display', 'flex');
+  await expect(timeline).toHaveCSS('padding-top', '56px');
+
+  const stageBars = timeline.locator('.htw-h-6.htw-relative');
+  const stageIcons = timeline.locator('.htw--top-12');
+  await expect(stageBars).toHaveCount(4);
+  await expect(stageIcons).toHaveCount(4);
+
+  for (let index = 0; index < 4; index += 1) {
+    await expect(stageBars.nth(index)).toHaveCSS('height', '24px');
+    await expect(stageBars.nth(index)).toHaveCSS('position', 'relative');
+    await expect(stageIcons.nth(index)).toHaveCSS('position', 'absolute');
+    await expect(stageIcons.nth(index)).toHaveCSS('top', '-48px');
+  }
+
+  await expect(page.getByText('Sent', { exact: true })).toBeVisible();
+  await expect(page.getByText('Finalized', { exact: true })).toBeVisible();
+  await expect(page.getByText('Validated', { exact: true })).toBeVisible();
+  await expect(page.getByText('Relayed', { exact: true })).toBeVisible();
+  await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  await expect(page.getByText('Sorry, an error has occurred. Please try again later.')).toHaveCount(
+    0,
+  );
+  expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
## What

- add a Playwright production-browser smoke test for the Explorer homepage, chain picker, and message timeline
- run it against the built Next app in the existing CI build job
- verify hydration, live Latest Messages data, POST GraphQL transport, and app/widget layout

## Why

The dependency upgrade passed build, typecheck, lint, unit tests, and Vercel deployment while the deployed app had three user-visible regressions:

- a Zustand 5 render loop during hydration
- urql 5 GET requests rejected by the GraphQL edge
- Tailwind 4 utilities losing to the unlayered widget preflight

This test exercises the actual browser/runtime/data path that those checks missed.

## Assertions

- search UI hydrates without uncaught page errors or the app error boundary
- at least one live message row renders
- GraphQL queries use POST, not GET
- header/footer logos and search input keep their compact production heights
- Origin, Destination, Time, and Status controls remain compact
- the Origin chain picker renders its search, controls, and chain rows as the intended grids
- a delivered message renders four timeline bars and four correctly positioned stage icons
- Jest excludes the Playwright-only smoke directory

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm exec jest --runInBand` — 14 suites / 129 tests pass
- `pnpm test:smoke` — 1 passed

Follows the merged runtime/style hotfix #343. This coverage is the gate for the separate Tailwind 4 migration follow-up.
