### PR TITLE
fix: add env override for API URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ AWS_ACCESS_KEY_ID=your_access_key_id
 AWS_SECRET_ACCESS_KEY=your_secret_access_key
 AWS_S3_BUCKET=your_bucket_name
 AWS_REGION=us-east-1
+
+# Explorer GraphQL API
+NEXT_PUBLIC_API_URL=http://localhost:8383/graphql

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/src/consts/config.ts
+++ b/src/consts/config.ts
@@ -1,5 +1,7 @@
 const isDevMode = process.env.NODE_ENV === 'development';
 const version = process.env.NEXT_PUBLIC_VERSION ?? null;
+const apiUrl =
+  process.env.NEXT_PUBLIC_API_URL || 'https://explorer4.hasura.app/v1/graphql';
 const registryUrl = process.env.NEXT_PUBLIC_REGISTRY_URL || undefined;
 const registryBranch = process.env.NEXT_PUBLIC_REGISTRY_BRANCH || 'main';
 const explorerApiKeys = JSON.parse(process.env.EXPLORER_API_KEYS || '{}');
@@ -17,7 +19,7 @@ interface Config {
 export const config: Config = Object.freeze({
   debug: isDevMode,
   version,
-  apiUrl: 'https://explorer4.hasura.app/v1/graphql',
+  apiUrl,
   explorerApiKeys,
   githubProxy: 'https://proxy.hyperlane.xyz',
   registryBranch,

--- a/src/consts/config.ts
+++ b/src/consts/config.ts
@@ -1,7 +1,6 @@
 const isDevMode = process.env.NODE_ENV === 'development';
 const version = process.env.NEXT_PUBLIC_VERSION ?? null;
-const apiUrl =
-  process.env.NEXT_PUBLIC_API_URL || 'https://explorer4.hasura.app/v1/graphql';
+const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'https://explorer4.hasura.app/v1/graphql';
 const registryUrl = process.env.NEXT_PUBLIC_REGISTRY_URL || undefined;
 const registryBranch = process.env.NEXT_PUBLIC_REGISTRY_BRANCH || 'main';
 const explorerApiKeys = JSON.parse(process.env.EXPLORER_API_KEYS || '{}');


### PR DESCRIPTION
## Summary
- Adds NEXT_PUBLIC_API_URL to .env.example
- Reads NEXT_PUBLIC_API_URL before falling back to the existing hosted GraphQL endpoint

## Testing
- Not run; env/config-only change