### PR TITLE
fix(messages): avoid BigNumber crash on non-EVM tx hashes

### DIFF
--- a/src/features/messages/cards/TransactionDetailsRows.tsx
+++ b/src/features/messages/cards/TransactionDetailsRows.tsx
@@ -1,5 +1,5 @@
 import type { ChainMetadataResolver } from '@hyperlane-xyz/sdk/metadata/ChainMetadataResolver';
-import BigNumber from 'bignumber.js';
+import { isZeroish } from '@hyperlane-xyz/utils';
 
 import { MessageTx, MessageTxStub } from '../../../types';
 import { formatTxHash } from '../../../utils/addresses';
@@ -28,7 +28,7 @@ export function TransactionDetailsRows({
 
   const formattedHash = formatTxHash(hash, domainId, resolver);
   const txExplorerLink =
-    hash && !new BigNumber(hash).isZero()
+    hash && !isZeroish(hash)
       ? getBlockExplorerTxUrl(resolver, chainName, formattedHash)
       : null;
   const fromExplorerLink = getBlockExplorerAddressUrl(resolver, chainName, from);

--- a/src/features/messages/cards/TransactionDetailsRows.tsx
+++ b/src/features/messages/cards/TransactionDetailsRows.tsx
@@ -28,9 +28,7 @@ export function TransactionDetailsRows({
 
   const formattedHash = formatTxHash(hash, domainId, resolver);
   const txExplorerLink =
-    hash && !isZeroish(hash)
-      ? getBlockExplorerTxUrl(resolver, chainName, formattedHash)
-      : null;
+    hash && !isZeroish(hash) ? getBlockExplorerTxUrl(resolver, chainName, formattedHash) : null;
   const fromExplorerLink = getBlockExplorerAddressUrl(resolver, chainName, from);
   const idString =
     chainName && chainName !== resolver.tryGetChainName(domainId)


### PR DESCRIPTION
## Summary
- The message details page crashed with `[BigNumber Error] Not a number` for any **non-EVM origin** (Solana, Cosmos, etc.).
- `TransactionDetailsRows.tsx` ran the raw origin tx hash through `bignumber.js` in the tx-explorer-link zero-check. Base58 hashes can't be parsed → throw → React error boundary → broken page (users saw a "500").
- Repro: https://explorer.hyperlane.xyz/message/0x6a52a8b23c44fef7db253b149432d6cf9e1bf31c43c0864cebd0f08029471aa3 (Solana → BSC). Origin tx hash `4zCF7vznfdjXyzDQkbvdLc5F6hfXWkset9PK8t6D5N3nsYU3dw2QCpcHSGuiSPHxoGwrjx8M4Rf25RJMwwueaTXM`.

## Fix
Use `isZeroish()` from `@hyperlane-xyz/utils` instead of a raw `new BigNumber(hash)`. It wraps the same zero-check in try/catch and returns `false` for non-numeric input, so EVM zero-hashes still suppress the link while non-EVM hashes render normally.

```diff
-import BigNumber from 'bignumber.js';
+import { isZeroish } from '@hyperlane-xyz/utils';
...
-    hash && !new BigNumber(hash).isZero()
+    hash && !isZeroish(hash)
```

## Test plan
- [ ] Load a Solana/Cosmos-origin message details page — no crash, tx link renders.
- [ ] Load an EVM-origin message with a real tx hash — tx link still renders.
- [ ] Load a message with an all-zero EVM tx hash — tx link is suppressed (unchanged behavior).