### PR TITLE
fix(warpFees): resolve underlying token for wrapper-collateral routes (lockbox + ERC4626)

### DIFF
--- a/src/features/messages/warpFees/fetchWarpFees.test.ts
+++ b/src/features/messages/warpFees/fetchWarpFees.test.ts
@@ -1,14 +1,17 @@
-import { BigNumber, utils } from 'ethers';
+import { TokenStandard } from '@hyperlane-xyz/sdk';
+import { BigNumber, providers, utils } from 'ethers';
 
-import type { MessageStub } from '../../../types';
+import type { MessageStub, WarpRouteDetails } from '../../../types';
 import {
   computeFeeBps,
   countReceivedTransferRemotes,
+  isLockboxStandard,
   isSyntheticSameChainCcrMessage,
   parseIgpPaymentForMessage,
   parseSentTransferRemoteAmount,
   parseSwapAmountFromBody,
   parseTotalTokenPulledFromUser,
+  resolveUserPullToken,
   sliceLogsForMessage,
 } from './fetchWarpFees';
 
@@ -190,6 +193,43 @@ describe('parseTotalTokenPulledFromUser', () => {
     ];
     const result = parseTotalTokenPulledFromUser(logs, ROUTER, TOKEN);
     expect(result?.eq(BigNumber.from('200000000'))).toBe(true);
+  });
+});
+
+describe('isLockboxStandard', () => {
+  it('is true for xERC20 lockbox standards', () => {
+    expect(isLockboxStandard(TokenStandard.EvmHypXERC20Lockbox)).toBe(true);
+    expect(isLockboxStandard(TokenStandard.EvmHypVSXERC20Lockbox)).toBe(true);
+  });
+
+  it('is false for collateral / synthetic standards', () => {
+    expect(isLockboxStandard(TokenStandard.EvmHypCollateral)).toBe(false);
+    expect(isLockboxStandard(TokenStandard.EvmHypSynthetic)).toBe(false);
+  });
+});
+
+describe('resolveUserPullToken', () => {
+  // Non-lockbox branches never touch the provider.
+  const provider = new providers.JsonRpcProvider('http://localhost:0');
+
+  function makeOriginToken(overrides: Partial<WarpRouteDetails['originToken']>) {
+    return {
+      standard: TokenStandard.EvmHypCollateral,
+      ...overrides,
+    } as WarpRouteDetails['originToken'];
+  }
+
+  it('uses collateralAddressOrDenom for collateral routes', async () => {
+    const originToken = makeOriginToken({
+      standard: TokenStandard.EvmHypCollateral,
+      collateralAddressOrDenom: TOKEN,
+    });
+    expect(await resolveUserPullToken(originToken, ROUTER, provider)).toBe(TOKEN);
+  });
+
+  it('falls back to the router for synthetic routes', async () => {
+    const originToken = makeOriginToken({ standard: TokenStandard.EvmHypSynthetic });
+    expect(await resolveUserPullToken(originToken, ROUTER, provider)).toBe(ROUTER);
   });
 });
 

--- a/src/features/messages/warpFees/fetchWarpFees.test.ts
+++ b/src/features/messages/warpFees/fetchWarpFees.test.ts
@@ -5,7 +5,6 @@ import type { MessageStub, WarpRouteDetails } from '../../../types';
 import {
   computeFeeBps,
   countReceivedTransferRemotes,
-  isLockboxStandard,
   isSyntheticSameChainCcrMessage,
   parseIgpPaymentForMessage,
   parseSentTransferRemoteAmount,
@@ -13,6 +12,7 @@ import {
   parseTotalTokenPulledFromUser,
   resolveUserPullToken,
   sliceLogsForMessage,
+  usesWrappedCollateral,
 } from './fetchWarpFees';
 
 const erc20Iface = new utils.Interface([
@@ -196,15 +196,20 @@ describe('parseTotalTokenPulledFromUser', () => {
   });
 });
 
-describe('isLockboxStandard', () => {
+describe('usesWrappedCollateral', () => {
   it('is true for xERC20 lockbox standards', () => {
-    expect(isLockboxStandard(TokenStandard.EvmHypXERC20Lockbox)).toBe(true);
-    expect(isLockboxStandard(TokenStandard.EvmHypVSXERC20Lockbox)).toBe(true);
+    expect(usesWrappedCollateral(TokenStandard.EvmHypXERC20Lockbox)).toBe(true);
+    expect(usesWrappedCollateral(TokenStandard.EvmHypVSXERC20Lockbox)).toBe(true);
   });
 
-  it('is false for collateral / synthetic standards', () => {
-    expect(isLockboxStandard(TokenStandard.EvmHypCollateral)).toBe(false);
-    expect(isLockboxStandard(TokenStandard.EvmHypSynthetic)).toBe(false);
+  it('is true for ERC4626 vault-collateral standards', () => {
+    expect(usesWrappedCollateral(TokenStandard.EvmHypOwnerCollateral)).toBe(true);
+    expect(usesWrappedCollateral(TokenStandard.EvmHypRebaseCollateral)).toBe(true);
+  });
+
+  it('is false for plain collateral / synthetic standards', () => {
+    expect(usesWrappedCollateral(TokenStandard.EvmHypCollateral)).toBe(false);
+    expect(usesWrappedCollateral(TokenStandard.EvmHypSynthetic)).toBe(false);
   });
 });
 

--- a/src/features/messages/warpFees/fetchWarpFees.ts
+++ b/src/features/messages/warpFees/fetchWarpFees.ts
@@ -1,12 +1,13 @@
 import {
+  HypXERC20Lockbox__factory, // eslint-disable-line camelcase
   IERC20__factory, // eslint-disable-line camelcase
   InterchainGasPaymaster__factory, // eslint-disable-line camelcase
   Mailbox__factory, // eslint-disable-line camelcase
   TokenRouter__factory, // eslint-disable-line camelcase
 } from '@hyperlane-xyz/core';
-import { PROTOCOL_TO_HYP_NATIVE_STANDARD } from '@hyperlane-xyz/sdk';
+import { LOCKBOX_STANDARDS, PROTOCOL_TO_HYP_NATIVE_STANDARD } from '@hyperlane-xyz/sdk';
 import { ProtocolType, fromWei, isEVMLike, parseWarpRouteMessage } from '@hyperlane-xyz/utils';
-import { BigNumber, constants } from 'ethers';
+import { BigNumber, constants, providers } from 'ethers';
 
 import { Message, MessageStub, WarpRouteDetails } from '../../../types';
 import { logger } from '../../../utils/logger';
@@ -37,12 +38,20 @@ type RawLog = { address: string; topics: Array<string>; data: string };
 // All HypNative standards across protocols, from the SDK (matches Token.isHypNative()).
 const HYP_NATIVE_STANDARDS = new Set<string>(Object.values(PROTOCOL_TO_HYP_NATIVE_STANDARD));
 
+// xERC20 lockbox standards (standard + Velodrome variants). Their
+// `collateralAddressOrDenom` points at the xERC20 lockbox, but the user pays
+// the lockbox's underlying wrapped ERC20 — see `resolveUserPullToken`.
+const LOCKBOX_STANDARD_SET = new Set<string>(LOCKBOX_STANDARDS);
+
 /**
  * Parse warp route fees from the origin transaction receipt.
  *
  * Two paths:
- *   - **ERC20 routes** (collateral / synthetic): fee = tokens pulled from user
- *     − `SentTransferRemote` amount, reversed through the token's scale.
+ *   - **ERC20 routes** (collateral / synthetic / xERC20 lockbox): fee = tokens
+ *     pulled from user − `SentTransferRemote` amount, reversed through the
+ *     token's scale. Lockbox routes pull the underlying wrapped ERC20, resolved
+ *     via `resolveUserPullToken` (their `collateralAddressOrDenom` is the
+ *     lockbox, not the token the user pays).
  *   - **Native routes** (`HypNative`): fee = (`tx.value` − `IGP.GasPayment.payment`)
  *     − `SentTransferRemote` amount. IGP is always excluded so it doesn't leak
  *     into "warp fee". Skipped for multi-send native txs since `tx.value`
@@ -122,9 +131,7 @@ export async function fetchWarpFees(
     : parseTotalTokenPulledFromUser(
         messageLogs,
         routerAddress,
-        // For collateral routes the ERC20 token differs from the router;
-        // for synthetic routes the router IS the ERC20 token.
-        warpRouteDetails.originToken.collateralAddressOrDenom ?? routerAddress,
+        await resolveUserPullToken(warpRouteDetails.originToken, routerAddress, provider),
       );
   if (!totalTransferred || totalTransferred.isZero()) return null;
 
@@ -146,6 +153,31 @@ export async function fetchWarpFees(
     tokenSymbol: symbol ?? 'tokens',
     totalSent: fromWei(totalTransferred.toString(), decimals),
   };
+}
+
+export function isLockboxStandard(standard: string): boolean {
+  return LOCKBOX_STANDARD_SET.has(standard);
+}
+
+/**
+ * The ERC20 the user actually pays into the route.
+ *
+ *   - Collateral routes: `collateralAddressOrDenom` (differs from the router).
+ *   - Synthetic routes: the router itself is the ERC20.
+ *   - xERC20 lockbox routes: `collateralAddressOrDenom` is the lockbox, but the
+ *     user pays its underlying wrapped ERC20 (e.g. USDT). Scanning the lockbox
+ *     address finds no user `Transfer` and hides the fee, so read the router's
+ *     `wrappedToken()` (it is a `HypXERC20Lockbox`).
+ */
+export async function resolveUserPullToken(
+  originToken: WarpRouteDetails['originToken'],
+  routerAddress: string,
+  provider: providers.Provider,
+): Promise<string> {
+  if (isLockboxStandard(originToken.standard)) {
+    return HypXERC20Lockbox__factory.connect(routerAddress, provider).wrappedToken();
+  }
+  return originToken.collateralAddressOrDenom ?? routerAddress;
 }
 
 /**

--- a/src/features/messages/warpFees/fetchWarpFees.ts
+++ b/src/features/messages/warpFees/fetchWarpFees.ts
@@ -1,11 +1,15 @@
 import {
-  HypXERC20Lockbox__factory, // eslint-disable-line camelcase
+  HypERC20Collateral__factory, // eslint-disable-line camelcase
   IERC20__factory, // eslint-disable-line camelcase
   InterchainGasPaymaster__factory, // eslint-disable-line camelcase
   Mailbox__factory, // eslint-disable-line camelcase
   TokenRouter__factory, // eslint-disable-line camelcase
 } from '@hyperlane-xyz/core';
-import { LOCKBOX_STANDARDS, PROTOCOL_TO_HYP_NATIVE_STANDARD } from '@hyperlane-xyz/sdk';
+import {
+  ERC4626_COLLATERAL_STANDARDS,
+  LOCKBOX_STANDARDS,
+  PROTOCOL_TO_HYP_NATIVE_STANDARD,
+} from '@hyperlane-xyz/sdk';
 import { ProtocolType, fromWei, isEVMLike, parseWarpRouteMessage } from '@hyperlane-xyz/utils';
 import { BigNumber, constants, providers } from 'ethers';
 
@@ -38,20 +42,25 @@ type RawLog = { address: string; topics: Array<string>; data: string };
 // All HypNative standards across protocols, from the SDK (matches Token.isHypNative()).
 const HYP_NATIVE_STANDARDS = new Set<string>(Object.values(PROTOCOL_TO_HYP_NATIVE_STANDARD));
 
-// xERC20 lockbox standards (standard + Velodrome variants). Their
-// `collateralAddressOrDenom` points at the xERC20 lockbox, but the user pays
-// the lockbox's underlying wrapped ERC20 — see `resolveUserPullToken`.
-const LOCKBOX_STANDARD_SET = new Set<string>(LOCKBOX_STANDARDS);
+// Standards whose `collateralAddressOrDenom` is a wrapper (xERC20 lockbox or
+// ERC4626 vault), not the ERC20 the user actually pays. For these the user
+// pull and the fee are in the router's underlying `wrappedToken()` — see
+// `resolveUserPullToken`.
+const WRAPPED_COLLATERAL_STANDARDS = new Set<string>([
+  ...LOCKBOX_STANDARDS,
+  ...ERC4626_COLLATERAL_STANDARDS,
+]);
 
 /**
  * Parse warp route fees from the origin transaction receipt.
  *
  * Two paths:
- *   - **ERC20 routes** (collateral / synthetic / xERC20 lockbox): fee = tokens
- *     pulled from user − `SentTransferRemote` amount, reversed through the
- *     token's scale. Lockbox routes pull the underlying wrapped ERC20, resolved
- *     via `resolveUserPullToken` (their `collateralAddressOrDenom` is the
- *     lockbox, not the token the user pays).
+ *   - **ERC20 routes** (collateral / synthetic / xERC20 lockbox / ERC4626 vault):
+ *     fee = tokens pulled from user − `SentTransferRemote` amount, reversed
+ *     through the token's scale. Lockbox and vault-collateral routes pull the
+ *     underlying wrapped ERC20, resolved via `resolveUserPullToken` (their
+ *     `collateralAddressOrDenom` is the lockbox / vault, not the token the user
+ *     pays).
  *   - **Native routes** (`HypNative`): fee = (`tx.value` − `IGP.GasPayment.payment`)
  *     − `SentTransferRemote` amount. IGP is always excluded so it doesn't leak
  *     into "warp fee". Skipped for multi-send native txs since `tx.value`
@@ -155,8 +164,8 @@ export async function fetchWarpFees(
   };
 }
 
-export function isLockboxStandard(standard: string): boolean {
-  return LOCKBOX_STANDARD_SET.has(standard);
+export function usesWrappedCollateral(standard: string): boolean {
+  return WRAPPED_COLLATERAL_STANDARDS.has(standard);
 }
 
 /**
@@ -164,18 +173,19 @@ export function isLockboxStandard(standard: string): boolean {
  *
  *   - Collateral routes: `collateralAddressOrDenom` (differs from the router).
  *   - Synthetic routes: the router itself is the ERC20.
- *   - xERC20 lockbox routes: `collateralAddressOrDenom` is the lockbox, but the
- *     user pays its underlying wrapped ERC20 (e.g. USDT). Scanning the lockbox
- *     address finds no user `Transfer` and hides the fee, so read the router's
- *     `wrappedToken()` (it is a `HypXERC20Lockbox`).
+ *   - xERC20 lockbox and ERC4626 vault-collateral routes: `collateralAddressOrDenom`
+ *     is the lockbox / vault, but the user pays (and is charged the fee in) the
+ *     router's underlying `wrappedToken()` (e.g. USDT). Scanning the wrapper
+ *     address finds no user `Transfer` and hides the fee, so read `wrappedToken()`
+ *     from the router (every affected router extends `HypERC20Collateral`).
  */
 export async function resolveUserPullToken(
   originToken: WarpRouteDetails['originToken'],
   routerAddress: string,
   provider: providers.Provider,
 ): Promise<string> {
-  if (isLockboxStandard(originToken.standard)) {
-    return HypXERC20Lockbox__factory.connect(routerAddress, provider).wrappedToken();
+  if (usesWrappedCollateral(originToken.standard)) {
+    return HypERC20Collateral__factory.connect(routerAddress, provider).wrappedToken();
   }
   return originToken.collateralAddressOrDenom ?? routerAddress;
 }


### PR DESCRIPTION
## Summary
The warp fee row was hidden for routes whose `collateralAddressOrDenom` is a wrapper, not the token the user pays:
- xERC20 lockbox: `EvmHypXERC20Lockbox`, `EvmHypVSXERC20Lockbox` (+ Tron variants) — `collateralAddressOrDenom` is the xERC20 lockbox.
- ERC4626 vault collateral: `EvmHypOwnerCollateral`, `EvmHypRebaseCollateral` (+ Tron variants) — `collateralAddressOrDenom` is the vault.

In both cases the user pays (and is charged the fee in) the router's underlying `wrappedToken()`. `fetchWarpFees` scanned the wrapper address for user `Transfer` events, found none, and returned `null`.

Fix: `resolveUserPullToken` reads the router's `wrappedToken()` for these standards (drawn from the SDK's `LOCKBOX_STANDARDS` + `ERC4626_COLLATERAL_STANDARDS`, so it stays in sync) instead of `collateralAddressOrDenom`.

Example: oUSDT ETH->Celo message `0xd5b90bad6f332045e9bff82c0163d58f2dc8ad055f9ec441b9fe31fa8948ddef` charged a 5 USDT fee (10,005 pulled, 10,000 bridged, 5 USDT to fee recipient via lockbox `0x6D265`) but showed no fee row.

## Test plan
- [x] `pnpm jest src/features/messages/warpFees/fetchWarpFees.test.ts` (41 passed) — added `usesWrappedCollateral` + `resolveUserPullToken` cases
- [x] `pnpm tsc` typecheck clean
- [x] `pnpm oxlint src/features/messages/warpFees/` clean
- [ ] Verify the fee row renders on the message page after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)