### PR TITLE
feat(messages): show halted chain and route warnings

### DIFF
--- a/src/consts/pausedRoutes.test.ts
+++ b/src/consts/pausedRoutes.test.ts
@@ -1,0 +1,56 @@
+import { isRoutePaused } from './pausedRoutes';
+
+describe('isRoutePaused', () => {
+  const infiniteTradingProtocolRoute = {
+    originDomainId: 10,
+    destinationDomainId: 8453,
+    sender: '0xb231e9c3bc267db389e3bf5d6ab26ca078c6123b',
+    recipient: '0xba8cd87120aca631f59231f9fd6c5469bbee3440',
+  };
+
+  it('matches a paused route', () => {
+    expect(isRoutePaused(infiniteTradingProtocolRoute)).toBe(true);
+  });
+
+  it('matches the paused Nesa route', () => {
+    expect(
+      isRoutePaused({
+        originDomainId: 1,
+        destinationDomainId: 41443,
+        sender: '0x230f1e241c621d5af670dad83ebcdd18971e2995',
+        recipient: '0xeec6574eabba52bac3f0277f2cd5ac7e67197886',
+      }),
+    ).toBe(true);
+  });
+
+  it('matches a paused route in reverse', () => {
+    expect(
+      isRoutePaused({
+        originDomainId: infiniteTradingProtocolRoute.destinationDomainId,
+        destinationDomainId: infiniteTradingProtocolRoute.originDomainId,
+        sender: infiniteTradingProtocolRoute.recipient,
+        recipient: infiniteTradingProtocolRoute.sender,
+      }),
+    ).toBe(true);
+  });
+
+  it('matches addresses case-insensitively', () => {
+    expect(
+      isRoutePaused({
+        ...infiniteTradingProtocolRoute,
+        sender: infiniteTradingProtocolRoute.sender.toUpperCase(),
+        recipient: infiniteTradingProtocolRoute.recipient.toUpperCase(),
+      }),
+    ).toBe(true);
+  });
+
+  it('does not pause unrelated routes between the same chains', () => {
+    expect(
+      isRoutePaused({
+        ...infiniteTradingProtocolRoute,
+        sender: '0x1111111111111111111111111111111111111111',
+        recipient: '0x2222222222222222222222222222222222222222',
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/consts/pausedRoutes.test.ts
+++ b/src/consts/pausedRoutes.test.ts
@@ -1,7 +1,7 @@
 import { isRoutePaused } from './pausedRoutes';
 
 describe('isRoutePaused', () => {
-  const infiniteTradingProtocolRoute = {
+  const pausedRoute = {
     originDomainId: 10,
     destinationDomainId: 8453,
     sender: '0xb231e9c3bc267db389e3bf5d6ab26ca078c6123b',
@@ -9,10 +9,10 @@ describe('isRoutePaused', () => {
   };
 
   it('matches a paused route', () => {
-    expect(isRoutePaused(infiniteTradingProtocolRoute)).toBe(true);
+    expect(isRoutePaused(pausedRoute)).toBe(true);
   });
 
-  it('matches the paused Nesa route', () => {
+  it('matches another configured paused route', () => {
     expect(
       isRoutePaused({
         originDomainId: 1,
@@ -26,10 +26,10 @@ describe('isRoutePaused', () => {
   it('matches a paused route in reverse', () => {
     expect(
       isRoutePaused({
-        originDomainId: infiniteTradingProtocolRoute.destinationDomainId,
-        destinationDomainId: infiniteTradingProtocolRoute.originDomainId,
-        sender: infiniteTradingProtocolRoute.recipient,
-        recipient: infiniteTradingProtocolRoute.sender,
+        originDomainId: pausedRoute.destinationDomainId,
+        destinationDomainId: pausedRoute.originDomainId,
+        sender: pausedRoute.recipient,
+        recipient: pausedRoute.sender,
       }),
     ).toBe(true);
   });
@@ -37,9 +37,9 @@ describe('isRoutePaused', () => {
   it('matches addresses case-insensitively', () => {
     expect(
       isRoutePaused({
-        ...infiniteTradingProtocolRoute,
-        sender: infiniteTradingProtocolRoute.sender.toUpperCase(),
-        recipient: infiniteTradingProtocolRoute.recipient.toUpperCase(),
+        ...pausedRoute,
+        sender: pausedRoute.sender.toUpperCase(),
+        recipient: pausedRoute.recipient.toUpperCase(),
       }),
     ).toBe(true);
   });
@@ -47,7 +47,7 @@ describe('isRoutePaused', () => {
   it('does not pause unrelated routes between the same chains', () => {
     expect(
       isRoutePaused({
-        ...infiniteTradingProtocolRoute,
+        ...pausedRoute,
         sender: '0x1111111111111111111111111111111111111111',
         recipient: '0x2222222222222222222222222222222222222222',
       }),

--- a/src/consts/pausedRoutes.test.ts
+++ b/src/consts/pausedRoutes.test.ts
@@ -1,6 +1,6 @@
-import { isRoutePaused } from './pausedRoutes';
+import { getMessagePauseType } from './pausedRoutes';
 
-describe('isRoutePaused', () => {
+describe('getMessagePauseType', () => {
   const pausedRoute = {
     originDomainId: 10,
     destinationDomainId: 8453,
@@ -9,48 +9,81 @@ describe('isRoutePaused', () => {
   };
 
   it('matches a paused route', () => {
-    expect(isRoutePaused(pausedRoute)).toBe(true);
+    expect(getMessagePauseType(pausedRoute)).toBe('route');
   });
 
   it('matches another configured paused route', () => {
     expect(
-      isRoutePaused({
-        originDomainId: 1,
-        destinationDomainId: 41443,
-        sender: '0x230f1e241c621d5af670dad83ebcdd18971e2995',
-        recipient: '0xeec6574eabba52bac3f0277f2cd5ac7e67197886',
+      getMessagePauseType({
+        originDomainId: 42161,
+        destinationDomainId: 1399811149,
+        sender: '0xef9295afcff293956e8b149b33449f246f6f107d',
+        recipient: 'Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp',
       }),
-    ).toBe(true);
+    ).toBe('route');
   });
 
   it('matches a paused route in reverse', () => {
     expect(
-      isRoutePaused({
+      getMessagePauseType({
         originDomainId: pausedRoute.destinationDomainId,
         destinationDomainId: pausedRoute.originDomainId,
         sender: pausedRoute.recipient,
         recipient: pausedRoute.sender,
       }),
-    ).toBe(true);
+    ).toBe('route');
   });
 
-  it('matches addresses case-insensitively', () => {
+  it('matches EVM addresses case-insensitively', () => {
     expect(
-      isRoutePaused({
+      getMessagePauseType({
         ...pausedRoute,
         sender: pausedRoute.sender.toUpperCase(),
         recipient: pausedRoute.recipient.toUpperCase(),
       }),
-    ).toBe(true);
+    ).toBe('route');
   });
 
   it('does not pause unrelated routes between the same chains', () => {
     expect(
-      isRoutePaused({
+      getMessagePauseType({
         ...pausedRoute,
         sender: '0x1111111111111111111111111111111111111111',
         recipient: '0x2222222222222222222222222222222222222222',
       }),
-    ).toBe(false);
+    ).toBeUndefined();
+  });
+
+  it('matches a halted origin chain without matching addresses', () => {
+    expect(
+      getMessagePauseType({
+        originDomainId: 1783,
+        destinationDomainId: 1,
+        sender: '0x1111111111111111111111111111111111111111',
+        recipient: '0x2222222222222222222222222222222222222222',
+      }),
+    ).toBe('chain');
+  });
+
+  it('matches a halted destination chain without matching addresses', () => {
+    expect(
+      getMessagePauseType({
+        originDomainId: 8453,
+        destinationDomainId: 1783,
+        sender: '0x1111111111111111111111111111111111111111',
+        recipient: '0x2222222222222222222222222222222222222222',
+      }),
+    ).toBe('chain');
+  });
+
+  it('does not pause route legs that exclude the halted chain', () => {
+    expect(
+      getMessagePauseType({
+        originDomainId: 1,
+        destinationDomainId: 8453,
+        sender: '0xeec6574eabba52bac3f0277f2cd5ac7e67197886',
+        recipient: '0x3eba6644819546c44eb3e7c3a92f034f921dca80',
+      }),
+    ).toBeUndefined();
   });
 });

--- a/src/consts/pausedRoutes.ts
+++ b/src/consts/pausedRoutes.ts
@@ -1,0 +1,51 @@
+import type { MessageStub } from '../types';
+
+interface RouteEndpoint {
+  domainId: number;
+  address: string;
+}
+
+export interface PausedRoute {
+  name: string;
+  endpoints: readonly [RouteEndpoint, RouteEndpoint];
+}
+
+// Route endpoint pairs that are temporarily paused due to security incidents.
+export const pausedRoutes = [
+  {
+    name: 'Infinite Trading Protocol',
+    endpoints: [
+      { domainId: 10, address: '0xb231e9c3bc267db389e3bf5d6ab26ca078c6123b' },
+      { domainId: 8453, address: '0xba8cd87120aca631f59231f9fd6c5469bbee3440' },
+    ],
+  },
+  {
+    name: 'Nesa',
+    endpoints: [
+      { domainId: 1, address: '0x230f1e241c621d5af670dad83ebcdd18971e2995' },
+      { domainId: 41443, address: '0xeec6574eabba52bac3f0277f2cd5ac7e67197886' },
+    ],
+  },
+] as const satisfies readonly PausedRoute[];
+
+type MessageRoute = Pick<
+  MessageStub,
+  'originDomainId' | 'destinationDomainId' | 'sender' | 'recipient'
+>;
+
+export function isRoutePaused(message: MessageRoute): boolean {
+  return pausedRoutes.some(({ endpoints: [first, second] }) => {
+    const matchesForward =
+      endpointMatches(first, message.originDomainId, message.sender) &&
+      endpointMatches(second, message.destinationDomainId, message.recipient);
+    const matchesReverse =
+      endpointMatches(second, message.originDomainId, message.sender) &&
+      endpointMatches(first, message.destinationDomainId, message.recipient);
+
+    return matchesForward || matchesReverse;
+  });
+}
+
+function endpointMatches(endpoint: RouteEndpoint, domainId: number, address: string): boolean {
+  return endpoint.domainId === domainId && endpoint.address.toLowerCase() === address.toLowerCase();
+}

--- a/src/consts/pausedRoutes.ts
+++ b/src/consts/pausedRoutes.ts
@@ -6,24 +6,30 @@ interface RouteEndpoint {
 }
 
 export interface PausedRoute {
-  name: string;
-  endpoints: readonly [RouteEndpoint, RouteEndpoint];
+  endpoints: readonly RouteEndpoint[];
 }
 
-// Route endpoint pairs that are temporarily paused due to security incidents.
+// Chains that are halted entirely. A message matches when either domain is listed.
+export const pausedChainDomainIds = [1783] as const;
+
+// Route endpoint groups that are temporarily paused due to security incidents.
+// A message matches when both its origin and destination endpoints belong to one group.
 export const pausedRoutes = [
   {
-    name: 'Infinite Trading Protocol',
     endpoints: [
       { domainId: 10, address: '0xb231e9c3bc267db389e3bf5d6ab26ca078c6123b' },
       { domainId: 8453, address: '0xba8cd87120aca631f59231f9fd6c5469bbee3440' },
     ],
   },
   {
-    name: 'Nesa',
     endpoints: [
+      { domainId: 42161, address: '0xef9295afcff293956e8b149b33449f246f6f107d' },
+      { domainId: 8453, address: '0x87ea09fe8d9dc6115086f5e0a30ca6750a997f1c' },
+      { domainId: 56, address: '0x3131f6b80c26936ab03f7d9d29eb4ddf36ac3fb5' },
       { domainId: 1, address: '0x230f1e241c621d5af670dad83ebcdd18971e2995' },
+      { domainId: 999, address: '0xd1b6443d49156b66e7bd8a37673511be68bfa459' },
       { domainId: 41443, address: '0xeec6574eabba52bac3f0277f2cd5ac7e67197886' },
+      { domainId: 1399811149, address: 'Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp' },
     ],
   },
 ] as const satisfies readonly PausedRoute[];
@@ -33,19 +39,36 @@ type MessageRoute = Pick<
   'originDomainId' | 'destinationDomainId' | 'sender' | 'recipient'
 >;
 
-export function isRoutePaused(message: MessageRoute): boolean {
-  return pausedRoutes.some(({ endpoints: [first, second] }) => {
-    const matchesForward =
-      endpointMatches(first, message.originDomainId, message.sender) &&
-      endpointMatches(second, message.destinationDomainId, message.recipient);
-    const matchesReverse =
-      endpointMatches(second, message.originDomainId, message.sender) &&
-      endpointMatches(first, message.destinationDomainId, message.recipient);
+export type MessagePauseType = 'chain' | 'route';
 
-    return matchesForward || matchesReverse;
+export function getMessagePauseType(message: MessageRoute): MessagePauseType | undefined {
+  const isPausedChain = pausedChainDomainIds.some(
+    (domainId) => domainId === message.originDomainId || domainId === message.destinationDomainId,
+  );
+  if (isPausedChain) return 'chain';
+
+  const isPausedRoute = pausedRoutes.some(({ endpoints }) => {
+    const originMatches = endpoints.some((endpoint) =>
+      endpointMatches(endpoint, message.originDomainId, message.sender),
+    );
+    const destinationMatches = endpoints.some((endpoint) =>
+      endpointMatches(endpoint, message.destinationDomainId, message.recipient),
+    );
+
+    return originMatches && destinationMatches;
   });
+
+  return isPausedRoute ? 'route' : undefined;
 }
 
 function endpointMatches(endpoint: RouteEndpoint, domainId: number, address: string): boolean {
-  return endpoint.domainId === domainId && endpoint.address.toLowerCase() === address.toLowerCase();
+  return endpoint.domainId === domainId && addressesEqual(endpoint.address, address);
+}
+
+function addressesEqual(first: string, second: string): boolean {
+  if (/^0x/i.test(first) && /^0x/i.test(second)) {
+    return first.toLowerCase() === second.toLowerCase();
+  }
+
+  return first === second;
 }

--- a/src/features/messages/cards/TransactionCard.test.tsx
+++ b/src/features/messages/cards/TransactionCard.test.tsx
@@ -1,0 +1,77 @@
+/** @jest-environment jsdom */
+
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { MessageStatus, type MessageStub } from '../../../types';
+import { DestinationTransactionCard } from './TransactionCard';
+
+jest.mock('@hyperlane-xyz/widgets', () => ({
+  ErrorIcon: () => null,
+  Modal: () => null,
+  SpinnerIcon: () => null,
+  Tooltip: () => null,
+  useModal: () => ({ isOpen: false, open: jest.fn(), close: jest.fn() }),
+}));
+
+jest.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: () => () => null,
+}));
+
+jest.mock('../../../components/icons/ChainLogo', () => ({ ChainLogo: () => null }));
+jest.mock('../../../components/layout/SectionCard', () => ({
+  SectionCard: ({ children }: { children: React.ReactNode }) => children,
+}));
+jest.mock('../../../store', () => ({
+  useMultiProvider: () => ({ tryGetChainMetadata: () => undefined }),
+}));
+jest.mock('../collateral/useCollateralStatus', () => ({
+  useCollateralStatus: () => ({ status: 'unknown' }),
+}));
+jest.mock('./CodeBlock', () => ({ LabelAndCodeBlock: () => null }));
+jest.mock('./CollateralCards', () => ({
+  ActiveRebalanceModal: () => null,
+  InsufficientCollateralWarning: () => null,
+}));
+jest.mock('./TransactionDetailsRows', () => ({ TransactionDetailsRows: () => null }));
+
+const reactTestGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+beforeAll(() => {
+  reactTestGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  delete reactTestGlobal.IS_REACT_ACT_ENVIRONMENT;
+});
+
+it('shows a halt warning before missing chain metadata', async () => {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  const message = {
+    originDomainId: 1783,
+    destinationDomainId: 999999,
+    sender: '0x1111111111111111111111111111111111111111',
+    recipient: '0x2222222222222222222222222222222222222222',
+  } as MessageStub;
+
+  await act(async () => {
+    root.render(
+      <DestinationTransactionCard
+        chainName="unknown"
+        domainId={message.destinationDomainId}
+        status={MessageStatus.Pending}
+        isStatusFetching={false}
+        blur={false}
+        message={message}
+      />,
+    );
+  });
+
+  expect(container.textContent).toContain('Chain Halted');
+  expect(container.textContent).not.toContain('Delivery status is unknown.');
+  await act(async () => root.unmount());
+});

--- a/src/features/messages/cards/TransactionCard.tsx
+++ b/src/features/messages/cards/TransactionCard.tsx
@@ -197,13 +197,13 @@ function PausedMessageWarning({ type }: { type: MessagePauseType }) {
       <div className="flex items-center gap-2">
         <ErrorIcon width={20} height={20} color={Color.red} />
         <h3 className="text-sm font-medium text-red-600">
-          {isChainHalted ? 'Chain Halted' : 'Route Paused'}
+          {isChainHalted ? 'Chain Halted' : 'Route Halted'}
         </h3>
       </div>
       <p className="text-sm leading-relaxed text-gray-700">
         {isChainHalted
           ? 'A chain involved in this message is currently halted. This message will not be processed while the chain remains halted, so its transferred assets will not be available on the destination chain.'
-          : 'This route is paused due to a security incident. This message will not be processed while the pause remains active, so its transferred assets will not be available on the destination chain.'}
+          : 'This route is halted due to a security incident. This message will not be processed while the pause remains active, so its transferred assets will not be available on the destination chain.'}
       </p>
     </div>
   );

--- a/src/features/messages/cards/TransactionCard.tsx
+++ b/src/features/messages/cards/TransactionCard.tsx
@@ -54,6 +54,8 @@ export function DestinationTransactionCard({
   const multiProvider = useMultiProvider();
   const hasChainConfig = !!multiProvider.tryGetChainMetadata(domainId);
   const collateralInfo = useCollateralStatus(message, warpRouteDetails);
+  const pauseType =
+    status === MessageStatus.Pending && message ? getMessagePauseType(message) : undefined;
 
   const { isOpen, open, close } = useModal();
 
@@ -110,6 +112,8 @@ export function DestinationTransactionCard({
         )}
       </>
     );
+  } else if (pauseType) {
+    content = <PausedMessageWarning type={pauseType} />;
   } else if (!hasChainConfig) {
     content = (
       <>
@@ -134,20 +138,18 @@ export function DestinationTransactionCard({
       </>
     );
   } else if (status === MessageStatus.Pending) {
-    const pauseType = message ? getMessagePauseType(message) : undefined;
     // Show collateral warning for pending routes when the explorer can query
     // the destination runtime directly. Today that path is EVM-only.
     const hasCollateralWarning = collateralInfo.status === CollateralStatus.Insufficient;
     content = (
       <>
-        {pauseType && <PausedMessageWarning type={pauseType} />}
-        {!pauseType && hasCollateralWarning && (
+        {hasCollateralWarning && (
           <InsufficientCollateralWarning
             warpRouteDetails={warpRouteDetails}
             collateralInfo={collateralInfo}
           />
         )}
-        {!pauseType && !hasCollateralWarning && (
+        {!hasCollateralWarning && (
           <DeliveryStatus>
             <div className="flex flex-col items-center">
               <div>Delivery to destination chain still in progress.</div>
@@ -191,6 +193,13 @@ export function DestinationTransactionCard({
 
 function PausedMessageWarning({ type }: { type: MessagePauseType }) {
   const isChainHalted = type === 'chain';
+  const message = isChainHalted
+    ? 'A chain involved in this message is currently halted. ' +
+      'This message will not be processed while the chain remains halted, so its ' +
+      'transferred assets will not be available on the destination chain.'
+    : 'This route is halted due to a security incident. ' +
+      'This message will not be processed while the route remains halted, so its ' +
+      'transferred assets will not be available on the destination chain.';
 
   return (
     <div className="space-y-3">
@@ -200,11 +209,7 @@ function PausedMessageWarning({ type }: { type: MessagePauseType }) {
           {isChainHalted ? 'Chain Halted' : 'Route Halted'}
         </h3>
       </div>
-      <p className="text-sm leading-relaxed text-gray-700">
-        {isChainHalted
-          ? 'A chain involved in this message is currently halted. This message will not be processed while the chain remains halted, so its transferred assets will not be available on the destination chain.'
-          : 'This route is halted due to a security incident. This message will not be processed while the pause remains active, so its transferred assets will not be available on the destination chain.'}
-      </p>
+      <p className="text-sm leading-relaxed text-gray-700">{message}</p>
     </div>
   );
 }

--- a/src/features/messages/cards/TransactionCard.tsx
+++ b/src/features/messages/cards/TransactionCard.tsx
@@ -5,7 +5,7 @@ import { PropsWithChildren, ReactNode, useId, useState } from 'react';
 import { ChainLogo } from '../../../components/icons/ChainLogo';
 import { SectionCard } from '../../../components/layout/SectionCard';
 import { links } from '../../../consts/links';
-import { isRoutePaused } from '../../../consts/pausedRoutes';
+import { getMessagePauseType, MessagePauseType } from '../../../consts/pausedRoutes';
 import { useMultiProvider } from '../../../store';
 import { Color } from '../../../styles/Color';
 import {
@@ -134,20 +134,20 @@ export function DestinationTransactionCard({
       </>
     );
   } else if (status === MessageStatus.Pending) {
+    const pauseType = message ? getMessagePauseType(message) : undefined;
     // Show collateral warning for pending routes when the explorer can query
     // the destination runtime directly. Today that path is EVM-only.
-    const hasPausedRouteWarning = !!message && isRoutePaused(message);
     const hasCollateralWarning = collateralInfo.status === CollateralStatus.Insufficient;
     content = (
       <>
-        {hasPausedRouteWarning && <PausedRouteWarning />}
-        {!hasPausedRouteWarning && hasCollateralWarning && (
+        {pauseType && <PausedMessageWarning type={pauseType} />}
+        {!pauseType && hasCollateralWarning && (
           <InsufficientCollateralWarning
             warpRouteDetails={warpRouteDetails}
             collateralInfo={collateralInfo}
           />
         )}
-        {!hasPausedRouteWarning && !hasCollateralWarning && (
+        {!pauseType && !hasCollateralWarning && (
           <DeliveryStatus>
             <div className="flex flex-col items-center">
               <div>Delivery to destination chain still in progress.</div>
@@ -189,17 +189,21 @@ export function DestinationTransactionCard({
   );
 }
 
-function PausedRouteWarning() {
+function PausedMessageWarning({ type }: { type: MessagePauseType }) {
+  const isChainHalted = type === 'chain';
+
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-2">
         <ErrorIcon width={20} height={20} color={Color.red} />
-        <h3 className="text-sm font-medium text-red-600">Route Paused</h3>
+        <h3 className="text-sm font-medium text-red-600">
+          {isChainHalted ? 'Chain Halted' : 'Route Paused'}
+        </h3>
       </div>
       <p className="text-sm leading-relaxed text-gray-700">
-        This route is paused due to a security incident. This message will not be processed while
-        the pause remains active, so its transferred assets will not be available on the destination
-        chain.
+        {isChainHalted
+          ? 'A chain involved in this message is currently halted. This message will not be processed while the chain remains halted, so its transferred assets will not be available on the destination chain.'
+          : 'This route is paused due to a security incident. This message will not be processed while the pause remains active, so its transferred assets will not be available on the destination chain.'}
       </p>
     </div>
   );

--- a/src/features/messages/cards/TransactionCard.tsx
+++ b/src/features/messages/cards/TransactionCard.tsx
@@ -1,10 +1,11 @@
-import { Modal, SpinnerIcon, Tooltip, useModal } from '@hyperlane-xyz/widgets';
+import { ErrorIcon, Modal, SpinnerIcon, Tooltip, useModal } from '@hyperlane-xyz/widgets';
 import dynamic from 'next/dynamic';
 import { PropsWithChildren, ReactNode, useId, useState } from 'react';
 
 import { ChainLogo } from '../../../components/icons/ChainLogo';
 import { SectionCard } from '../../../components/layout/SectionCard';
 import { links } from '../../../consts/links';
+import { isRoutePaused } from '../../../consts/pausedRoutes';
 import { useMultiProvider } from '../../../store';
 import { Color } from '../../../styles/Color';
 import {
@@ -135,16 +136,18 @@ export function DestinationTransactionCard({
   } else if (status === MessageStatus.Pending) {
     // Show collateral warning for pending routes when the explorer can query
     // the destination runtime directly. Today that path is EVM-only.
+    const hasPausedRouteWarning = !!message && isRoutePaused(message);
     const hasCollateralWarning = collateralInfo.status === CollateralStatus.Insufficient;
     content = (
       <>
-        {hasCollateralWarning && (
+        {hasPausedRouteWarning && <PausedRouteWarning />}
+        {!hasPausedRouteWarning && hasCollateralWarning && (
           <InsufficientCollateralWarning
             warpRouteDetails={warpRouteDetails}
             collateralInfo={collateralInfo}
           />
         )}
-        {!hasCollateralWarning && (
+        {!hasPausedRouteWarning && !hasCollateralWarning && (
           <DeliveryStatus>
             <div className="flex flex-col items-center">
               <div>Delivery to destination chain still in progress.</div>
@@ -183,6 +186,22 @@ export function DestinationTransactionCard({
     >
       {content}
     </TransactionCard>
+  );
+}
+
+function PausedRouteWarning() {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <ErrorIcon width={20} height={20} color={Color.red} />
+        <h3 className="text-sm font-medium text-red-600">Route Paused</h3>
+      </div>
+      <p className="text-sm leading-relaxed text-gray-700">
+        This route is paused due to a security incident. This message will not be processed while
+        the pause remains active, so its transferred assets will not be available on the destination
+        chain.
+      </p>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- Show a blocking warning in the destination card for pending messages involving halted chains or configured halted routes.
- Keep chain-wide halts separate from endpoint-specific route halts to avoid warning on unaffected route legs.
- Explain that affected messages will not be processed and transferred assets remain unavailable on the destination chain.

<img width="903" height="216" alt="image" src="https://github.com/user-attachments/assets/860be523-b5d6-4e99-afcb-5c9f3de4a67c" />

