### PR TITLE
fix(messages): keep loading state during filter searches

### DIFF
--- a/src/features/messages/MessageSearch.tsx
+++ b/src/features/messages/MessageSearch.tsx
@@ -220,7 +220,7 @@ export function MessageSearch() {
   const isAnyFetching = isFetching || piSearchState.isFetching;
   const isAnyError = isError || piSearchState.isError;
   const hasAllRun = hasRun && (!shouldRunPiSearch || piSearchState.hasRun);
-  const isReadyToShowEmptyState = hasAllRun && isChainMetadataReady;
+  const isSearchSettled = hasAllRun && isChainMetadataReady;
   const isAnyMessageFound = isMessagesFound || piSearchState.isMessagesFound;
   const messageListResult = isMessagesFound ? messageList : piSearchState.messageList;
   const messageTableKey = [
@@ -381,29 +381,22 @@ export function MessageSearch() {
             <RefreshButton loading={isAnyFetching} onClick={refetch} />
           </div>
         </div>
-        <Fade show={showMessageTable && !redirectUrl}>
-          <MessageTable
-            key={messageTableKey}
-            messageList={messageListResult}
-            isFetching={isAnyFetching}
-          />
-        </Fade>
+        {isSearchSettled && (
+          <Fade show={showMessageTable && !redirectUrl}>
+            <MessageTable
+              key={messageTableKey}
+              messageList={messageListResult}
+              isFetching={isAnyFetching}
+            />
+          </Fade>
+        )}
         <SearchFetching
-          show={
-            !isAnyError &&
-            isValidInput &&
-            !isAnyMessageFound &&
-            (!hasAllRun || !isChainMetadataReady)
-          }
+          show={!isAnyError && isValidInput && !isSearchSettled}
           isPiFetching={piSearchState.isFetching}
         />
         <SearchEmptyError
           show={
-            !redirectUrl &&
-            !isAnyError &&
-            isValidInput &&
-            !isAnyMessageFound &&
-            isReadyToShowEmptyState
+            !redirectUrl && !isAnyError && isValidInput && !isAnyMessageFound && isSearchSettled
           }
           hasInput={hasInput}
           allowAddress={true}

--- a/src/features/messages/queries/useMessageQuery.test.ts
+++ b/src/features/messages/queries/useMessageQuery.test.ts
@@ -2,6 +2,7 @@ import { MessageStatus, MessageStub } from '../../../types';
 import { adjustToUtcTime } from '../../../utils/time';
 import { MessageIdentifierType, buildMessageQuery, buildMessageSearchQuery } from './build';
 import {
+  doesQueryResultMatchRequest,
   getSearchMetadataState,
   getMessageSearchDomainIds,
   messageMatchesSearchFilters,
@@ -18,6 +19,16 @@ const OTHER = '0x' + '33'.repeat(20);
 // Alpha hex digits so upper/lower casing actually differ — needed to exercise
 // case-insensitive address comparison.
 const ROUTER_MIXED = '0x' + 'ab'.repeat(20);
+
+describe('doesQueryResultMatchRequest', () => {
+  it('rejects preserved data from the previous filter request', () => {
+    expect(doesQueryResultMatchRequest(2, 1)).toBe(false);
+  });
+
+  it('keeps the current result settled during a background refresh', () => {
+    expect(doesQueryResultMatchRequest(2, 2)).toBe(true);
+  });
+});
 
 function makeStub(overrides: Partial<MessageStub> = {}): MessageStub {
   return {

--- a/src/features/messages/queries/useMessageQuery.ts
+++ b/src/features/messages/queries/useMessageQuery.ts
@@ -1,6 +1,6 @@
 import { eqAddress, isAddress } from '@hyperlane-xyz/utils';
 import { useCallback, useMemo } from 'react';
-import { useQuery } from 'urql';
+import { createRequest, useQuery } from 'urql';
 
 import { useChainMetadataResolver } from '../../../metadataStore';
 import { MessageStatus, MessageStatusFilter, MessageStub } from '../../../types';
@@ -57,6 +57,10 @@ export function shouldUseMessageQueryCache(connectionState: ExplorerConnectionSt
 
 export function shouldPollMessageSearch(isLiveConnected: boolean, hasFilters: boolean) {
   return !isLiveConnected || hasFilters;
+}
+
+export function doesQueryResultMatchRequest(requestKey: number, resultOperationKey?: number) {
+  return requestKey === resultOperationKey;
 }
 
 export function getMessageSearchDomainIds(
@@ -259,6 +263,9 @@ export function useMessageSearchQuery(
     requestPolicy: 'cache-and-network',
   });
   const { data, fetching, error } = result;
+  const hasCurrentQueryResult =
+    !!data &&
+    doesQueryResultMatchRequest(createRequest(query, variables).key, result.operation?.key);
   const isFetching = isValidInput && !isSearchMetadataError && (!isSearchMetadataReady || fetching);
   const refresh = useCallback(() => {
     if (!query || !isValidInput) return;
@@ -339,7 +346,7 @@ export function useMessageSearchQuery(
     isValidDestination,
     isFetching,
     isError: isSearchMetadataError || !!error,
-    hasRun: isSearchMetadataReady && !!data,
+    hasRun: isSearchMetadataReady && hasCurrentQueryResult,
     isMessagesFound,
     messageList,
     refetch: refresh,


### PR DESCRIPTION
## Summary

- wait for results from the current filter request before showing rows or the empty state
- keep genuinely empty results stable during same-query background refreshes
- mount the first filtered result batch as the table baseline so historical rows do not get the live-message insertion animation
- cover current-request matching and background-refresh behavior with regression tests

## Test plan

- `pnpm test --runInBand`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`