### PR TITLE
ci: benchmark Depot migration

### DIFF
--- a/.depot/workflows/ci-benchmark.yml
+++ b/.depot/workflows/ci-benchmark.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-11-depot-comparison-v1-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-depot-comparison-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.depot/workflows/ci-benchmark.yml
+++ b/.depot/workflows/ci-benchmark.yml
@@ -1,0 +1,49 @@
+name: CI benchmark (Depot)
+
+on:
+  pull_request:
+    branches: [ci/migrate-to-depot]
+
+jobs:
+  benchmark:
+    runs-on: depot-ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        id: pnpm-cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-11-depot-comparison-v1-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Format
+        run: |
+          pnpm run format
+          test -z "$(git status --short)"
+
+      - name: Report cache state
+        run: echo "pnpm-cache-hit=${{ steps.pnpm-cache.outputs.cache-hit }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-benchmark.yml
+++ b/.github/workflows/ci-benchmark.yml
@@ -1,0 +1,49 @@
+name: CI benchmark (GitHub)
+
+on:
+  pull_request:
+    branches: [ci/migrate-to-depot]
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        id: pnpm-cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-11-depot-comparison-v1-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Format
+        run: |
+          pnpm run format
+          test -z "$(git status --short)"
+
+      - name: Report cache state
+        run: echo "pnpm-cache-hit=${{ steps.pnpm-cache.outputs.cache-hit }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
 name: CI benchmark (GitHub)
 
 on:
-  pull_request:
-    branches: [ci/migrate-to-depot]
+  workflow_dispatch:
 
 jobs:
   benchmark:
@@ -26,7 +25,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-11-depot-comparison-v1-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-depot-comparison-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Temporary controlled benchmark for #352.

- identical GitHub and Depot workflows except runner label
- same source SHA, commands, pnpm cache key, and runner OS
- first attempt measures cold cache; sequential rerun measures warm cache

This PR will be closed and its branch deleted after results are recorded on #352.
