### PR TITLE
feat(messages): link halted incident notices

### DIFF
--- a/src/consts/pausedRoutes.test.ts
+++ b/src/consts/pausedRoutes.test.ts
@@ -1,4 +1,4 @@
-import { getMessagePauseType } from './pausedRoutes';
+import { getMessagePause, getMessagePauseType } from './pausedRoutes';
 
 describe('getMessagePauseType', () => {
   const pausedRoute = {
@@ -74,6 +74,41 @@ describe('getMessagePauseType', () => {
         recipient: '0x2222222222222222222222222222222222222222',
       }),
     ).toBe('chain');
+  });
+
+  it('returns the configured link for a halted chain', () => {
+    expect(
+      getMessagePause({
+        originDomainId: 1783,
+        destinationDomainId: 1,
+        sender: '0x1111111111111111111111111111111111111111',
+        recipient: '0x2222222222222222222222222222222222222222',
+      }),
+    ).toEqual({
+      type: 'chain',
+      link: 'https://x.com/KiiChainio/status/2091330990027296992',
+    });
+  });
+
+  it('returns the configured link for a halted route', () => {
+    expect(getMessagePause(pausedRoute)).toEqual({
+      type: 'route',
+      link: 'https://x.com/InfiniteTradePr/status/2090409024437039569',
+    });
+  });
+
+  it('returns another configured route link', () => {
+    expect(
+      getMessagePause({
+        originDomainId: 42161,
+        destinationDomainId: 1399811149,
+        sender: '0xef9295afcff293956e8b149b33449f246f6f107d',
+        recipient: 'Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp',
+      }),
+    ).toEqual({
+      type: 'route',
+      link: 'https://x.com/nesaorg/status/2091915864497066077',
+    });
   });
 
   it('does not pause route legs that exclude the halted chain', () => {

--- a/src/consts/pausedRoutes.ts
+++ b/src/consts/pausedRoutes.ts
@@ -5,23 +5,38 @@ interface RouteEndpoint {
   address: string;
 }
 
-export interface PausedRoute {
+interface PauseConfig {
+  link?: string;
+}
+
+export interface PausedChain extends PauseConfig {
+  domainId: number;
+}
+
+export interface PausedRoute extends PauseConfig {
   endpoints: readonly RouteEndpoint[];
 }
 
 // Chains that are halted entirely. A message matches when either domain is listed.
-export const pausedChainDomainIds = [1783] as const;
+export const pausedChains: readonly PausedChain[] = [
+  {
+    domainId: 1783,
+    link: 'https://x.com/KiiChainio/status/2091330990027296992',
+  },
+];
 
 // Route endpoint groups that are temporarily paused due to security incidents.
 // A message matches when both its origin and destination endpoints belong to one group.
-export const pausedRoutes = [
+export const pausedRoutes: readonly PausedRoute[] = [
   {
+    link: 'https://x.com/InfiniteTradePr/status/2090409024437039569',
     endpoints: [
       { domainId: 10, address: '0xb231e9c3bc267db389e3bf5d6ab26ca078c6123b' },
       { domainId: 8453, address: '0xba8cd87120aca631f59231f9fd6c5469bbee3440' },
     ],
   },
   {
+    link: 'https://x.com/nesaorg/status/2091915864497066077',
     endpoints: [
       { domainId: 42161, address: '0xef9295afcff293956e8b149b33449f246f6f107d' },
       { domainId: 8453, address: '0x87ea09fe8d9dc6115086f5e0a30ca6750a997f1c' },
@@ -32,7 +47,7 @@ export const pausedRoutes = [
       { domainId: 1399811149, address: 'Ht37Rn665vxVD4mChW7Qf9r5MnGJQQwLAdfBZzpoKqTp' },
     ],
   },
-] as const satisfies readonly PausedRoute[];
+];
 
 type MessageRoute = Pick<
   MessageStub,
@@ -41,13 +56,19 @@ type MessageRoute = Pick<
 
 export type MessagePauseType = 'chain' | 'route';
 
-export function getMessagePauseType(message: MessageRoute): MessagePauseType | undefined {
-  const isPausedChain = pausedChainDomainIds.some(
-    (domainId) => domainId === message.originDomainId || domainId === message.destinationDomainId,
-  );
-  if (isPausedChain) return 'chain';
+export interface MessagePause {
+  type: MessagePauseType;
+  link?: string;
+}
 
-  const isPausedRoute = pausedRoutes.some(({ endpoints }) => {
+export function getMessagePause(message: MessageRoute): MessagePause | undefined {
+  const pausedChain = pausedChains.find(
+    ({ domainId }) =>
+      domainId === message.originDomainId || domainId === message.destinationDomainId,
+  );
+  if (pausedChain) return { type: 'chain', link: pausedChain.link };
+
+  const pausedRoute = pausedRoutes.find(({ endpoints }) => {
     const originMatches = endpoints.some((endpoint) =>
       endpointMatches(endpoint, message.originDomainId, message.sender),
     );
@@ -58,7 +79,11 @@ export function getMessagePauseType(message: MessageRoute): MessagePauseType | u
     return originMatches && destinationMatches;
   });
 
-  return isPausedRoute ? 'route' : undefined;
+  return pausedRoute ? { type: 'route', link: pausedRoute.link } : undefined;
+}
+
+export function getMessagePauseType(message: MessageRoute): MessagePauseType | undefined {
+  return getMessagePause(message)?.type;
 }
 
 function endpointMatches(endpoint: RouteEndpoint, domainId: number, address: string): boolean {

--- a/src/consts/pausedRoutes.ts
+++ b/src/consts/pausedRoutes.ts
@@ -5,30 +5,21 @@ interface RouteEndpoint {
   address: string;
 }
 
-interface PauseConfig {
-  link?: string;
-}
+export type MessagePauseType = 'chain' | 'route';
 
-export interface PausedChain extends PauseConfig {
-  domainId: number;
-}
+export type PauseConfig =
+  | { type: 'chain'; domainId: number; link?: string }
+  | { type: 'route'; endpoints: readonly RouteEndpoint[]; link?: string };
 
-export interface PausedRoute extends PauseConfig {
-  endpoints: readonly RouteEndpoint[];
-}
-
-// Chains that are halted entirely. A message matches when either domain is listed.
-export const pausedChains: readonly PausedChain[] = [
+// Chain configs match either domain; route configs match both endpoints.
+export const pauseConfigs: readonly PauseConfig[] = [
   {
+    type: 'chain',
     domainId: 1783,
     link: 'https://x.com/KiiChainio/status/2091330990027296992',
   },
-];
-
-// Route endpoint groups that are temporarily paused due to security incidents.
-// A message matches when both its origin and destination endpoints belong to one group.
-export const pausedRoutes: readonly PausedRoute[] = [
   {
+    type: 'route',
     link: 'https://x.com/InfiniteTradePr/status/2090409024437039569',
     endpoints: [
       { domainId: 10, address: '0xb231e9c3bc267db389e3bf5d6ab26ca078c6123b' },
@@ -36,6 +27,7 @@ export const pausedRoutes: readonly PausedRoute[] = [
     ],
   },
   {
+    type: 'route',
     link: 'https://x.com/nesaorg/status/2091915864497066077',
     endpoints: [
       { domainId: 42161, address: '0xef9295afcff293956e8b149b33449f246f6f107d' },
@@ -54,32 +46,26 @@ type MessageRoute = Pick<
   'originDomainId' | 'destinationDomainId' | 'sender' | 'recipient'
 >;
 
-export type MessagePauseType = 'chain' | 'route';
+export function getMessagePause(message: MessageRoute) {
+  const pause = pauseConfigs.find((config) => {
+    if (config.type === 'chain') {
+      return (
+        config.domainId === message.originDomainId ||
+        config.domainId === message.destinationDomainId
+      );
+    }
 
-export interface MessagePause {
-  type: MessagePauseType;
-  link?: string;
-}
-
-export function getMessagePause(message: MessageRoute): MessagePause | undefined {
-  const pausedChain = pausedChains.find(
-    ({ domainId }) =>
-      domainId === message.originDomainId || domainId === message.destinationDomainId,
-  );
-  if (pausedChain) return { type: 'chain', link: pausedChain.link };
-
-  const pausedRoute = pausedRoutes.find(({ endpoints }) => {
-    const originMatches = endpoints.some((endpoint) =>
+    const originMatches = config.endpoints.some((endpoint) =>
       endpointMatches(endpoint, message.originDomainId, message.sender),
     );
-    const destinationMatches = endpoints.some((endpoint) =>
+    const destinationMatches = config.endpoints.some((endpoint) =>
       endpointMatches(endpoint, message.destinationDomainId, message.recipient),
     );
 
     return originMatches && destinationMatches;
   });
 
-  return pausedRoute ? { type: 'route', link: pausedRoute.link } : undefined;
+  return pause ? { type: pause.type, link: pause.link } : undefined;
 }
 
 export function getMessagePauseType(message: MessageRoute): MessagePauseType | undefined {

--- a/src/features/messages/cards/TransactionCard.test.tsx
+++ b/src/features/messages/cards/TransactionCard.test.tsx
@@ -73,5 +73,10 @@ it('shows a halt warning before missing chain metadata', async () => {
 
   expect(container.textContent).toContain('Chain Halted');
   expect(container.textContent).not.toContain('Delivery status is unknown.');
+  const link = container.querySelector('a');
+  expect(link?.textContent).toBe('Read more about this');
+  expect(link?.getAttribute('href')).toBe('https://x.com/KiiChainio/status/2091330990027296992');
+  expect(link?.getAttribute('target')).toBe('_blank');
+  expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
   await act(async () => root.unmount());
 });

--- a/src/features/messages/cards/TransactionCard.tsx
+++ b/src/features/messages/cards/TransactionCard.tsx
@@ -5,7 +5,7 @@ import { PropsWithChildren, ReactNode, useId, useState } from 'react';
 import { ChainLogo } from '../../../components/icons/ChainLogo';
 import { SectionCard } from '../../../components/layout/SectionCard';
 import { links } from '../../../consts/links';
-import { getMessagePauseType, MessagePauseType } from '../../../consts/pausedRoutes';
+import { getMessagePause, MessagePauseType } from '../../../consts/pausedRoutes';
 import { useMultiProvider } from '../../../store';
 import { Color } from '../../../styles/Color';
 import {
@@ -54,8 +54,7 @@ export function DestinationTransactionCard({
   const multiProvider = useMultiProvider();
   const hasChainConfig = !!multiProvider.tryGetChainMetadata(domainId);
   const collateralInfo = useCollateralStatus(message, warpRouteDetails);
-  const pauseType =
-    status === MessageStatus.Pending && message ? getMessagePauseType(message) : undefined;
+  const pause = status === MessageStatus.Pending && message ? getMessagePause(message) : undefined;
 
   const { isOpen, open, close } = useModal();
 
@@ -112,8 +111,8 @@ export function DestinationTransactionCard({
         )}
       </>
     );
-  } else if (pauseType) {
-    content = <PausedMessageWarning type={pauseType} />;
+  } else if (pause) {
+    content = <PausedMessageWarning type={pause.type} link={pause.link} />;
   } else if (!hasChainConfig) {
     content = (
       <>
@@ -191,7 +190,7 @@ export function DestinationTransactionCard({
   );
 }
 
-function PausedMessageWarning({ type }: { type: MessagePauseType }) {
+function PausedMessageWarning({ type, link }: { type: MessagePauseType; link?: string }) {
   const isChainHalted = type === 'chain';
   const message = isChainHalted
     ? 'A chain involved in this message is currently halted. ' +
@@ -210,6 +209,16 @@ function PausedMessageWarning({ type }: { type: MessagePauseType }) {
         </h3>
       </div>
       <p className="text-sm leading-relaxed text-gray-700">{message}</p>
+      {link && (
+        <a
+          href={link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block text-sm text-gray-700 underline underline-offset-2 hover:text-gray-900"
+        >
+          Read more about this
+        </a>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Add optional links to halted chain and route configuration.
- Show an underlined “Read more about this” link in destination warnings when configured.
- Link the current halt warnings to their official incident posts and cover each mapping.
