### PR TITLE
Remove kiichain from explorer halted list

### DIFF
--- a/src/consts/pausedRoutes.test.ts
+++ b/src/consts/pausedRoutes.test.ts
@@ -54,42 +54,6 @@ describe('getMessagePauseType', () => {
     ).toBeUndefined();
   });
 
-  it('matches a halted origin chain without matching addresses', () => {
-    expect(
-      getMessagePauseType({
-        originDomainId: 1783,
-        destinationDomainId: 1,
-        sender: '0x1111111111111111111111111111111111111111',
-        recipient: '0x2222222222222222222222222222222222222222',
-      }),
-    ).toBe('chain');
-  });
-
-  it('matches a halted destination chain without matching addresses', () => {
-    expect(
-      getMessagePauseType({
-        originDomainId: 8453,
-        destinationDomainId: 1783,
-        sender: '0x1111111111111111111111111111111111111111',
-        recipient: '0x2222222222222222222222222222222222222222',
-      }),
-    ).toBe('chain');
-  });
-
-  it('returns the configured link for a halted chain', () => {
-    expect(
-      getMessagePause({
-        originDomainId: 1783,
-        destinationDomainId: 1,
-        sender: '0x1111111111111111111111111111111111111111',
-        recipient: '0x2222222222222222222222222222222222222222',
-      }),
-    ).toEqual({
-      type: 'chain',
-      link: 'https://x.com/KiiChainio/status/2091330990027296992',
-    });
-  });
-
   it('returns the configured link for a halted route', () => {
     expect(getMessagePause(pausedRoute)).toEqual({
       type: 'route',

--- a/src/consts/pausedRoutes.ts
+++ b/src/consts/pausedRoutes.ts
@@ -14,11 +14,6 @@ export type PauseConfig =
 // Chain configs match either domain; route configs match both endpoints.
 export const pauseConfigs: readonly PauseConfig[] = [
   {
-    type: 'chain',
-    domainId: 1783,
-    link: 'https://x.com/KiiChainio/status/2091330990027296992',
-  },
-  {
     type: 'route',
     link: 'https://x.com/InfiniteTradePr/status/2090409024437039569',
     endpoints: [


### PR DESCRIPTION
## Summary
- Kiichain (Hyperlane domain 1783) is active again, so remove its chain-halt entry from the Explorer's paused list.
- Drop the now-obsolete kiichain chain-halt unit tests; remaining route-pause tests are unchanged.

Requested by @Xaroz  — kiichain confirmed active.

## Test plan
- [x] `pnpm jest src/consts/pausedRoutes.test.ts` (8 passed)