### PR TITLE
fix: respect scraper proxy transaction query limit

### DIFF
--- a/src/features/transactions/useTransactionMessagesQuery.ts
+++ b/src/features/transactions/useTransactionMessagesQuery.ts
@@ -9,7 +9,7 @@ import { MessagesQueryResult } from '../messages/queries/fragments';
 import { parseMessageQueryResult } from '../messages/queries/parse';
 
 const TX_AUTO_REFRESH_DELAY = 10_000; // 10s
-const TX_QUERY_LIMIT = 1000; // Max messages per transaction
+const TX_QUERY_LIMIT = 500; // Scraper proxy maximum
 
 /**
  * Hook to query all messages dispatched in a single origin transaction.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "npx --yes pnpm@11.20.0 install --frozen-lockfile",
+  "buildCommand": "npx --yes pnpm@11.20.0 run build"
+}


### PR DESCRIPTION
## Summary

- cap transaction-page message queries at 500 rows
- match scraper-proxy's enforced GraphQL query limit
- restore transaction page loading without weakening the server-side resource bound
- invoke the pinned pnpm version directly for Vercel install and build

## Context

Explorer requested `limit: 1000`, while scraper-proxy rejects any `limit` above 500. This made transaction pages fail before querying PostgreSQL with `[GraphQL] limit exceeds maximum of 500`.

The server-side bound was added in response to the [scraper-proxy #9238 review finding](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9238#discussion_r3760020493) requiring an enforced default/max row count independent of client arguments. Scraper-proxy now defines the maximum as 500 [here](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/c5bf59d329a09b6abf6c0d58ef0d486ca4a8ac6e/typescript/scraper-proxy/src/scraperdb/sql.ts#L41-L48) and validates requested limits against it [here](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/c5bf59d329a09b6abf6c0d58ef0d486ca4a8ac6e/typescript/scraper-proxy/src/scraperdb/sql.ts#L280-L282).

The transaction page already compares the returned rows with the aggregate count and displays `Showing first N of M messages`, so respecting the proxy cap preserves the existing truncation behavior.

Main does not yet contain the direct-pnpm Vercel configuration from #357. Without it, this PR's initial preview failed before deployment. `vercel.json` now pins both install and build to the repository's `pnpm@11.20.0`; the updated preview succeeds.

Reproduction: https://explorer.hyperlane.xyz/tx/0x7459ec10da848db8e1fb669cb32820fc715d405a55e5a3b4fc316c0bf6fcc9d7

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec oxfmt --check src/features/transactions/useTransactionMessagesQuery.ts`
- `npx --yes pnpm@11.20.0 install --frozen-lockfile`
- `npx --yes pnpm@11.20.0 run build`
- Vercel preview succeeded at `e42d1eb`
- live GraphQL: `limit: 1000` reproduces the error; `limit: 500` returns the transaction's two messages
- `pnpm test --runInBand`: 195 passed, 1 unrelated baseline failure in `TransactionCard.test.tsx`; main removed KiiChain from the halted list in #356 but the test still expects `Chain Halted`
